### PR TITLE
[codex] Add shield-aware item descriptors

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -256,6 +256,11 @@ func (conn *Conn) GameData() GameData {
 	return conn.gameData
 }
 
+// ShieldID returns the runtime item ID of minecraft:shield for this connection.
+func (conn *Conn) ShieldID() int32 {
+	return conn.shieldID.Load()
+}
+
 // Proto returns the protocol of the connection.
 func (conn *Conn) Proto() Protocol {
 	return conn.proto

--- a/minecraft/conn_shield_test.go
+++ b/minecraft/conn_shield_test.go
@@ -1,0 +1,11 @@
+package minecraft_test
+
+import (
+	"testing"
+
+	"github.com/sandertv/gophertunnel/minecraft"
+)
+
+func TestConnExposesShieldID(t *testing.T) {
+	var _ interface{ ShieldID() int32 } = (*minecraft.Conn)(nil)
+}

--- a/minecraft/protocol/inventory.go
+++ b/minecraft/protocol/inventory.go
@@ -34,10 +34,10 @@ type InventoryAction struct {
 	InventorySlot uint32
 	// OldItem is the item that was present in the slot before the inventory action. It should be checked by
 	// the server to ensure the inventories were not out of sync.
-	OldItem ItemInstance
+	OldItem NetworkItemStackDescriptor
 	// NewItem is the new item that was put in the InventorySlot that the OldItem was in. It must be checked
 	// in combination with other inventory actions to ensure that the transaction is balanced.
-	NewItem ItemInstance
+	NewItem NetworkItemStackDescriptor
 }
 
 // Marshal encodes/decodes an InventoryAction.
@@ -50,8 +50,8 @@ func (x *InventoryAction) Marshal(r IO) {
 		r.Varuint32(&x.SourceFlags)
 	}
 	r.Varuint32(&x.InventorySlot)
-	r.ItemInstance(&x.OldItem)
-	r.ItemInstance(&x.NewItem)
+	Single(r, &x.OldItem)
+	Single(r, &x.NewItem)
 }
 
 const (
@@ -175,7 +175,7 @@ type UseItemTransactionData struct {
 	HotBarSlot int32
 	// HeldItem is the item that was held to interact with the block. The server should check if this item
 	// is actually present in the HotBarSlot.
-	HeldItem ItemInstance
+	HeldItem NetworkItemStackDescriptor
 	// Position is the position of the player at the time of interaction. For clicking a block, this is the
 	// position at that time, whereas for breaking the block it is the position at the time of breaking.
 	Position mgl32.Vec3
@@ -212,7 +212,7 @@ type UseItemOnEntityTransactionData struct {
 	HotBarSlot int32
 	// HeldItem is the item that was held to interact with the entity. The server should check if this item
 	// is actually present in the HotBarSlot.
-	HeldItem ItemInstance
+	HeldItem NetworkItemStackDescriptor
 	// Position is the position of the player at the time of clicking the entity.
 	Position mgl32.Vec3
 	// ClickedPosition is the position that was clicked relative to the entity's base coordinate. It can be
@@ -238,7 +238,7 @@ type ReleaseItemTransactionData struct {
 	HotBarSlot int32
 	// HeldItem is the item that was released. The server should check if this item is actually present in the
 	// HotBarSlot.
-	HeldItem ItemInstance
+	HeldItem NetworkItemStackDescriptor
 	// HeadPosition is the position of the player's head at the time of releasing the item. This is used
 	// mainly for purposes such as spawning eating particles at that position.
 	HeadPosition mgl32.Vec3
@@ -251,7 +251,7 @@ func (data *UseItemTransactionData) Marshal(r IO) {
 	r.BlockPos(&data.BlockPosition)
 	r.Varint32(&data.BlockFace)
 	r.Varint32(&data.HotBarSlot)
-	r.ItemInstance(&data.HeldItem)
+	Single(r, &data.HeldItem)
 	r.Vec3(&data.Position)
 	r.Vec3(&data.ClickedPosition)
 	r.Varuint32(&data.BlockRuntimeID)
@@ -264,7 +264,7 @@ func (data *UseItemOnEntityTransactionData) Marshal(r IO) {
 	r.Varuint64(&data.TargetEntityRuntimeID)
 	r.Varuint32(&data.ActionType)
 	r.Varint32(&data.HotBarSlot)
-	r.ItemInstance(&data.HeldItem)
+	Single(r, &data.HeldItem)
 	r.Vec3(&data.Position)
 	r.Vec3(&data.ClickedPosition)
 }
@@ -273,7 +273,7 @@ func (data *UseItemOnEntityTransactionData) Marshal(r IO) {
 func (data *ReleaseItemTransactionData) Marshal(r IO) {
 	r.Varuint32(&data.ActionType)
 	r.Varint32(&data.HotBarSlot)
-	r.ItemInstance(&data.HeldItem)
+	Single(r, &data.HeldItem)
 	r.Vec3(&data.HeadPosition)
 }
 

--- a/minecraft/protocol/item.go
+++ b/minecraft/protocol/item.go
@@ -15,6 +15,8 @@ type ItemInstance struct {
 	// field. If not, the field should be set to 1 if the server authoritative inventories are disabled in the
 	// StartGame packet, or to a unique stack ID if it is enabled.
 	StackNetworkID int32
+	// StackNetworkIDVariant is the ID namespace that StackNetworkID belongs to.
+	StackNetworkIDVariant uint32
 	// Stack is the actual item stack of the item instance.
 	Stack ItemStack
 }

--- a/minecraft/protocol/network_item_stack_descriptor.go
+++ b/minecraft/protocol/network_item_stack_descriptor.go
@@ -61,7 +61,7 @@ func InstanceToDescriptor(i ItemInstance, shieldID int32) NetworkItemStackDescri
 	}
 	if i.StackNetworkID != 0 {
 		d.NetIDVariant = Option(NetworkItemStackNetIDVariant{
-			Type:  NetworkItemStackNetIDVariantStack,
+			Type:  i.StackNetworkIDVariant,
 			Value: i.StackNetworkID,
 		})
 	}
@@ -70,6 +70,25 @@ func InstanceToDescriptor(i ItemInstance, shieldID int32) NetworkItemStackDescri
 
 // DescriptorToInstance converts a NetworkItemStackDescriptor into a legacy ItemInstance.
 func DescriptorToInstance(d NetworkItemStackDescriptor, shieldID int32) ItemInstance {
+	i, err := SafeDescriptorToInstance(d, shieldID)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+// SafeDescriptorToInstance converts a NetworkItemStackDescriptor into a legacy ItemInstance, returning an
+// error if its user data buffer is malformed.
+func SafeDescriptorToInstance(d NetworkItemStackDescriptor, shieldID int32) (i ItemInstance, err error) {
+	defer func() {
+		if recoveredErr := recover(); recoveredErr != nil {
+			err = recoveredErr.(error)
+		}
+	}()
+	return descriptorToInstance(d, shieldID, true), nil
+}
+
+func descriptorToInstance(d NetworkItemStackDescriptor, shieldID int32, enableLimits bool) ItemInstance {
 	if d.NetworkID == 0 {
 		return ItemInstance{}
 	}
@@ -85,9 +104,9 @@ func DescriptorToInstance(d NetworkItemStackDescriptor, shieldID int32) ItemInst
 		},
 	}
 	if v, ok := d.NetIDVariant.Value(); ok {
-		i.StackNetworkID = v.Value
+		i.StackNetworkID, i.StackNetworkIDVariant = v.Value, v.Type
 	}
-	unmarshalNetworkItemUserData(&i.Stack, d.UserDataBuffer, shieldID)
+	unmarshalNetworkItemUserData(&i.Stack, d.UserDataBuffer, shieldID, enableLimits)
 	return i
 }
 
@@ -118,13 +137,13 @@ func marshalNetworkItemUserData(x ItemStack, shieldID int32) []byte {
 	return append([]byte(nil), buf.Bytes()...)
 }
 
-func unmarshalNetworkItemUserData(x *ItemStack, data string, shieldID int32) {
+func unmarshalNetworkItemUserData(x *ItemStack, data string, shieldID int32, enableLimits bool) {
 	if data == "" {
 		x.NBTData, x.CanBePlacedOn, x.CanBreak = nil, nil, nil
 		x.BlockingTick = 0
 		return
 	}
-	r := NewReader(bytes.NewBufferString(data), shieldID, false)
+	r := NewReader(bytes.NewBufferString(data), shieldID, enableLimits)
 
 	var length int16
 	r.Int16(&length)

--- a/minecraft/protocol/network_item_stack_descriptor.go
+++ b/minecraft/protocol/network_item_stack_descriptor.go
@@ -1,0 +1,155 @@
+package protocol
+
+import (
+	"bytes"
+
+	"github.com/sandertv/gophertunnel/minecraft/internal"
+	"github.com/sandertv/gophertunnel/minecraft/nbt"
+)
+
+const (
+	NetworkItemStackNetIDVariantStack uint32 = iota
+	NetworkItemStackNetIDVariantItemStackRequest
+	NetworkItemStackNetIDVariantLegacyRequest
+)
+
+// NetworkItemStackNetIDVariant identifies which net-ID space produced a descriptor net ID.
+type NetworkItemStackNetIDVariant struct {
+	Type  uint32
+	Value int32
+}
+
+// Marshal encodes or decodes x.
+func (x *NetworkItemStackNetIDVariant) Marshal(r IO) {
+	r.Varuint32(&x.Type)
+	r.Varint32(&x.Value)
+}
+
+// NetworkItemStackDescriptor is the 1.26.20 network item stack descriptor used by MobEquipment and
+// InventorySlot.
+type NetworkItemStackDescriptor struct {
+	NetworkID      int16
+	Count          uint16
+	MetadataValue  uint32
+	NetIDVariant   Optional[NetworkItemStackNetIDVariant]
+	BlockRuntimeID uint32
+	UserDataBuffer string
+}
+
+// Marshal encodes or decodes x.
+func (x *NetworkItemStackDescriptor) Marshal(r IO) {
+	r.Int16(&x.NetworkID)
+	r.Uint16(&x.Count)
+	r.Varuint32(&x.MetadataValue)
+	OptionalMarshaler[NetworkItemStackNetIDVariant, *NetworkItemStackNetIDVariant](r, &x.NetIDVariant)
+	r.Varuint32(&x.BlockRuntimeID)
+	r.String(&x.UserDataBuffer)
+}
+
+// InstanceToDescriptor converts a legacy ItemInstance into a NetworkItemStackDescriptor.
+func InstanceToDescriptor(i ItemInstance, shieldID int32) NetworkItemStackDescriptor {
+	x := i.Stack
+	if x.NetworkID == 0 {
+		return NetworkItemStackDescriptor{}
+	}
+	d := NetworkItemStackDescriptor{
+		NetworkID:      int16(x.NetworkID),
+		Count:          x.Count,
+		MetadataValue:  x.MetadataValue,
+		BlockRuntimeID: uint32(x.BlockRuntimeID),
+		UserDataBuffer: string(marshalNetworkItemUserData(x, shieldID)),
+	}
+	if i.StackNetworkID != 0 {
+		d.NetIDVariant = Option(NetworkItemStackNetIDVariant{
+			Type:  NetworkItemStackNetIDVariantStack,
+			Value: i.StackNetworkID,
+		})
+	}
+	return d
+}
+
+// DescriptorToInstance converts a NetworkItemStackDescriptor into a legacy ItemInstance.
+func DescriptorToInstance(d NetworkItemStackDescriptor, shieldID int32) ItemInstance {
+	if d.NetworkID == 0 {
+		return ItemInstance{}
+	}
+	i := ItemInstance{
+		Stack: ItemStack{
+			ItemType: ItemType{
+				NetworkID:     int32(d.NetworkID),
+				MetadataValue: d.MetadataValue,
+			},
+			BlockRuntimeID: int32(d.BlockRuntimeID),
+			Count:          d.Count,
+			HasNetworkID:   true,
+		},
+	}
+	if v, ok := d.NetIDVariant.Value(); ok {
+		i.StackNetworkID = v.Value
+	}
+	unmarshalNetworkItemUserData(&i.Stack, d.UserDataBuffer, shieldID)
+	return i
+}
+
+func marshalNetworkItemUserData(x ItemStack, shieldID int32) []byte {
+	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		buf.Reset()
+		internal.BufferPool.Put(buf)
+	}()
+
+	w := NewWriter(buf, shieldID)
+	var length int16
+	if len(x.NBTData) != 0 {
+		length = -1
+		version := uint8(1)
+		w.Int16(&length)
+		w.Uint8(&version)
+		w.NBT(&x.NBTData, nbt.LittleEndian)
+	} else {
+		w.Int16(&length)
+	}
+	FuncSliceUint32Length(w, &x.CanBePlacedOn, w.StringUTF)
+	FuncSliceUint32Length(w, &x.CanBreak, w.StringUTF)
+	if x.NetworkID == shieldID {
+		w.Int64(&x.BlockingTick)
+	}
+	return append([]byte(nil), buf.Bytes()...)
+}
+
+func unmarshalNetworkItemUserData(x *ItemStack, data string, shieldID int32) {
+	if data == "" {
+		x.NBTData, x.CanBePlacedOn, x.CanBreak = nil, nil, nil
+		x.BlockingTick = 0
+		return
+	}
+	r := NewReader(bytes.NewBufferString(data), shieldID, false)
+
+	var length int16
+	r.Int16(&length)
+	switch {
+	case length == -1:
+		var version uint8
+		r.Uint8(&version)
+		switch version {
+		case 1:
+			r.NBT(&x.NBTData, nbt.LittleEndian)
+		default:
+			r.UnknownEnumOption(version, "item user data version")
+			return
+		}
+	case length > 0:
+		r.NBT(&x.NBTData, nbt.LittleEndian)
+	default:
+		x.NBTData = nil
+	}
+
+	FuncSliceUint32Length(r, &x.CanBePlacedOn, r.StringUTF)
+	FuncSliceUint32Length(r, &x.CanBreak, r.StringUTF)
+	if x.NetworkID == shieldID {
+		r.Int64(&x.BlockingTick)
+	} else {
+		x.BlockingTick = 0
+	}
+}

--- a/minecraft/protocol/network_item_stack_descriptor_test.go
+++ b/minecraft/protocol/network_item_stack_descriptor_test.go
@@ -1,0 +1,108 @@
+package protocol_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestNetworkItemStackDescriptorRoundTripsShieldBlockingTick(t *testing.T) {
+	const shieldID int32 = 512
+	in := protocol.ItemInstance{
+		StackNetworkID: 77,
+		Stack: protocol.ItemStack{
+			ItemType: protocol.ItemType{
+				NetworkID:     shieldID,
+				MetadataValue: 4,
+			},
+			BlockRuntimeID: 1234,
+			Count:          2,
+			NBTData: map[string]any{
+				"display": map[string]any{"Name": "guard"},
+			},
+			CanBePlacedOn: []string{"minecraft:stone"},
+			CanBreak:      []string{"minecraft:dirt"},
+			HasNetworkID:  true,
+			BlockingTick:  987654321,
+		},
+	}
+
+	desc := protocol.InstanceToDescriptor(in, shieldID)
+	out := protocol.DescriptorToInstance(desc, shieldID)
+
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("descriptor round trip mismatch:\nin:  %#v\nout: %#v", in, out)
+	}
+}
+
+func TestNetworkItemStackDescriptorOmitsBlockingTickForNonShield(t *testing.T) {
+	const shieldID int32 = 512
+	in := protocol.ItemInstance{
+		StackNetworkID: 78,
+		Stack: protocol.ItemStack{
+			ItemType: protocol.ItemType{
+				NetworkID:     42,
+				MetadataValue: 1,
+			},
+			BlockRuntimeID: 555,
+			Count:          3,
+			HasNetworkID:   true,
+			BlockingTick:   987654321,
+		},
+	}
+
+	desc := protocol.InstanceToDescriptor(in, shieldID)
+	out := protocol.DescriptorToInstance(desc, shieldID)
+
+	if out.Stack.BlockingTick != 0 {
+		t.Fatalf("non-shield blocking tick = %v, want 0", out.Stack.BlockingTick)
+	}
+	if out.Stack.NetworkID != in.Stack.NetworkID || out.Stack.Count != in.Stack.Count {
+		t.Fatalf("non-shield descriptor changed item identity: in=%#v out=%#v", in, out)
+	}
+}
+
+func TestNetworkItemStackDescriptorRoundTripsEmptyItem(t *testing.T) {
+	const shieldID int32 = 512
+	out := protocol.DescriptorToInstance(protocol.InstanceToDescriptor(protocol.ItemInstance{}, shieldID), shieldID)
+	if !reflect.DeepEqual(out, protocol.ItemInstance{}) {
+		t.Fatalf("empty descriptor round trip = %#v, want empty ItemInstance", out)
+	}
+}
+
+func TestMobEquipmentUsesNetworkItemStackDescriptor(t *testing.T) {
+	const shieldID int32 = 512
+	in := protocol.ItemInstance{
+		StackNetworkID: 79,
+		Stack: protocol.ItemStack{
+			ItemType: protocol.ItemType{
+				NetworkID:     shieldID,
+				MetadataValue: 0,
+			},
+			Count:        1,
+			HasNetworkID: true,
+			BlockingTick: 123,
+		},
+	}
+	pk := &packet.MobEquipment{
+		EntityRuntimeID: 1,
+		NewItem:         protocol.InstanceToDescriptor(in, shieldID),
+		InventorySlot:   0,
+		HotBarSlot:      0,
+		WindowID:        protocol.WindowIDInventory,
+	}
+
+	var buf bytes.Buffer
+	pk.Marshal(protocol.NewWriter(&buf, shieldID))
+
+	var decoded packet.MobEquipment
+	decoded.Marshal(protocol.NewReader(bytes.NewBuffer(buf.Bytes()), shieldID, true))
+	out := protocol.DescriptorToInstance(decoded.NewItem, shieldID)
+
+	if out.Stack.BlockingTick != in.Stack.BlockingTick {
+		t.Fatalf("decoded blocking tick = %v, want %v", out.Stack.BlockingTick, in.Stack.BlockingTick)
+	}
+}

--- a/minecraft/protocol/network_item_stack_descriptor_test.go
+++ b/minecraft/protocol/network_item_stack_descriptor_test.go
@@ -73,6 +73,40 @@ func TestNetworkItemStackDescriptorRoundTripsEmptyItem(t *testing.T) {
 	}
 }
 
+func TestNetworkItemStackDescriptorPreservesNetIDVariant(t *testing.T) {
+	const shieldID int32 = 512
+	in := protocol.NetworkItemStackDescriptor{
+		NetworkID:     42,
+		Count:         1,
+		MetadataValue: 3,
+		NetIDVariant: protocol.Option(protocol.NetworkItemStackNetIDVariant{
+			Type:  protocol.NetworkItemStackNetIDVariantLegacyRequest,
+			Value: 99,
+		}),
+		UserDataBuffer: string([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+	}
+
+	out := protocol.InstanceToDescriptor(protocol.DescriptorToInstance(in, shieldID), shieldID)
+	variant, ok := out.NetIDVariant.Value()
+	if !ok {
+		t.Fatal("net ID variant missing after round trip")
+	}
+	if variant.Type != protocol.NetworkItemStackNetIDVariantLegacyRequest || variant.Value != 99 {
+		t.Fatalf("net ID variant = %#v, want legacy request 99", variant)
+	}
+}
+
+func TestSafeDescriptorToInstanceReturnsErrorForMalformedUserData(t *testing.T) {
+	_, err := protocol.SafeDescriptorToInstance(protocol.NetworkItemStackDescriptor{
+		NetworkID:      42,
+		Count:          1,
+		UserDataBuffer: string([]byte{0xff}),
+	}, 512)
+	if err == nil {
+		t.Fatal("expected malformed descriptor user data to return an error")
+	}
+}
+
 func TestMobEquipmentUsesNetworkItemStackDescriptor(t *testing.T) {
 	const shieldID int32 = 512
 	in := protocol.ItemInstance{

--- a/minecraft/protocol/packet/add_item_actor.go
+++ b/minecraft/protocol/packet/add_item_actor.go
@@ -17,7 +17,7 @@ type AddItemActor struct {
 	EntityRuntimeID uint64
 	// Item is the item that is spawned. It must have a valid ID for it to show up client-side. If it is not
 	// a valid item, the client will crash when coming near.
-	Item protocol.ItemInstance
+	Item protocol.NetworkItemStackDescriptor
 	// Position is the position to spawn the entity on. If the entity is on a distance that the player cannot
 	// see it, the entity will still show up if the player moves closer.
 	Position mgl32.Vec3
@@ -41,7 +41,7 @@ func (*AddItemActor) ID() uint32 {
 func (pk *AddItemActor) Marshal(io protocol.IO) {
 	io.Varint64(&pk.EntityUniqueID)
 	io.Varuint64(&pk.EntityRuntimeID)
-	io.ItemInstance(&pk.Item)
+	protocol.Single(io, &pk.Item)
 	io.Vec3(&pk.Position)
 	io.Vec3(&pk.Velocity)
 	io.EntityMetadata(&pk.EntityMetadata)

--- a/minecraft/protocol/packet/add_player.go
+++ b/minecraft/protocol/packet/add_player.go
@@ -40,7 +40,7 @@ type AddPlayer struct {
 	// HeldItem is the item that the player is holding. The item is shown to the viewer as soon as the player
 	// itself shows up. Needless to say that this field is rather pointless, as additional packets still must
 	// be sent for armour to show up.
-	HeldItem protocol.ItemInstance
+	HeldItem protocol.NetworkItemStackDescriptor
 	// GameType is the game type of the player. If set to GameTypeSpectator, the player will not be shown to viewers.
 	GameType int32
 	// EntityMetadata is a map of entity metadata, which includes flags and data properties that alter in
@@ -79,7 +79,7 @@ func (pk *AddPlayer) Marshal(io protocol.IO) {
 	io.Float32(&pk.Pitch)
 	io.Float32(&pk.Yaw)
 	io.Float32(&pk.HeadYaw)
-	io.ItemInstance(&pk.HeldItem)
+	protocol.Single(io, &pk.HeldItem)
 	io.Varint32(&pk.GameType)
 	io.EntityMetadata(&pk.EntityMetadata)
 	protocol.Single(io, &pk.EntityProperties)

--- a/minecraft/protocol/packet/inventory_content.go
+++ b/minecraft/protocol/packet/inventory_content.go
@@ -13,13 +13,13 @@ type InventoryContent struct {
 	WindowID uint32
 	// Content is the new content of the inventory. The length of this slice must be equal to the full size of
 	// the inventory window updated.
-	Content []protocol.ItemInstance
+	Content []protocol.NetworkItemStackDescriptor
 	// Container is the protocol.FullContainerName that describes the container that the content is for.
 	Container protocol.FullContainerName
 	// StorageItem is the item that is acting as the storage container for the inventory. If the inventory is
 	// not a dynamic container then this field should be left empty. When set, only the item type is used by
 	// the client and none of the other stack info.
-	StorageItem protocol.ItemInstance
+	StorageItem protocol.NetworkItemStackDescriptor
 }
 
 // ID ...
@@ -29,7 +29,7 @@ func (*InventoryContent) ID() uint32 {
 
 func (pk *InventoryContent) Marshal(io protocol.IO) {
 	io.Varuint32(&pk.WindowID)
-	protocol.FuncSlice(io, &pk.Content, io.ItemInstance)
+	protocol.Slice(io, &pk.Content)
 	protocol.Single(io, &pk.Container)
-	io.ItemInstance(&pk.StorageItem)
+	protocol.Single(io, &pk.StorageItem)
 }

--- a/minecraft/protocol/packet/inventory_slot.go
+++ b/minecraft/protocol/packet/inventory_slot.go
@@ -16,13 +16,9 @@ type InventorySlot struct {
 	Slot uint32
 	// Container is the protocol.FullContainerName that describes the container that the content is for.
 	Container protocol.Optional[protocol.FullContainerName]
-	// StorageItem is the item that is acting as the storage container for the inventory. If the inventory is
-	// not a dynamic container then this field should be left empty. When set, only the item type is used by
-	// the client and none of the other stack info.
-	StorageItem protocol.Optional[protocol.ItemInstance]
 	// NewItem is the item to be put in the slot at Slot. It will overwrite any item that may currently
 	// be present in that slot.
-	NewItem protocol.ItemInstance
+	NewItem protocol.NetworkItemStackDescriptor
 }
 
 // ID ...
@@ -34,6 +30,5 @@ func (pk *InventorySlot) Marshal(io protocol.IO) {
 	io.Varuint32(&pk.WindowID)
 	io.Varuint32(&pk.Slot)
 	protocol.OptionalMarshaler(io, &pk.Container)
-	protocol.OptionalFunc(io, &pk.StorageItem, io.ItemInstanceNew)
-	io.ItemInstanceNew(&pk.NewItem)
+	protocol.Single(io, &pk.NewItem)
 }

--- a/minecraft/protocol/packet/inventory_slot.go
+++ b/minecraft/protocol/packet/inventory_slot.go
@@ -16,6 +16,10 @@ type InventorySlot struct {
 	Slot uint32
 	// Container is the protocol.FullContainerName that describes the container that the content is for.
 	Container protocol.Optional[protocol.FullContainerName]
+	// StorageItem is the item that is acting as the storage container for the inventory. If the inventory is
+	// not a dynamic container then this field should be left empty. When set, only the item type is used by
+	// the client and none of the other stack info.
+	StorageItem protocol.Optional[protocol.NetworkItemStackDescriptor]
 	// NewItem is the item to be put in the slot at Slot. It will overwrite any item that may currently
 	// be present in that slot.
 	NewItem protocol.NetworkItemStackDescriptor
@@ -30,5 +34,6 @@ func (pk *InventorySlot) Marshal(io protocol.IO) {
 	io.Varuint32(&pk.WindowID)
 	io.Varuint32(&pk.Slot)
 	protocol.OptionalMarshaler(io, &pk.Container)
+	protocol.OptionalMarshaler(io, &pk.StorageItem)
 	protocol.Single(io, &pk.NewItem)
 }

--- a/minecraft/protocol/packet/mob_armour_equipment.go
+++ b/minecraft/protocol/packet/mob_armour_equipment.go
@@ -12,17 +12,17 @@ type MobArmourEquipment struct {
 	EntityRuntimeID uint64
 	// Helmet is the equipped helmet of the entity. Items that are not wearable on the head will not be
 	// rendered by the client. Unlike in Java Edition, blocks cannot be worn.
-	Helmet protocol.ItemInstance
+	Helmet protocol.NetworkItemStackDescriptor
 	// Chestplate is the chestplate of the entity. Items that are not wearable as chestplate will not be
 	// rendered.
-	Chestplate protocol.ItemInstance
+	Chestplate protocol.NetworkItemStackDescriptor
 	// Leggings is the item worn as leggings by the entity. Items not wearable as leggings will not be
 	// rendered client-side.
-	Leggings protocol.ItemInstance
+	Leggings protocol.NetworkItemStackDescriptor
 	// Boots is the item worn as boots by the entity. Items not wearable as boots will not be rendered.
-	Boots protocol.ItemInstance
+	Boots protocol.NetworkItemStackDescriptor
 	// Body is the item worn on the body of the entity. Items not wearable on the body will not be rendered.
-	Body protocol.ItemInstance
+	Body protocol.NetworkItemStackDescriptor
 }
 
 // ID ...
@@ -32,9 +32,9 @@ func (*MobArmourEquipment) ID() uint32 {
 
 func (pk *MobArmourEquipment) Marshal(io protocol.IO) {
 	io.Varuint64(&pk.EntityRuntimeID)
-	io.ItemInstance(&pk.Helmet)
-	io.ItemInstance(&pk.Chestplate)
-	io.ItemInstance(&pk.Leggings)
-	io.ItemInstance(&pk.Boots)
-	io.ItemInstance(&pk.Body)
+	protocol.Single(io, &pk.Helmet)
+	protocol.Single(io, &pk.Chestplate)
+	protocol.Single(io, &pk.Leggings)
+	protocol.Single(io, &pk.Boots)
+	protocol.Single(io, &pk.Body)
 }

--- a/minecraft/protocol/packet/mob_equipment.go
+++ b/minecraft/protocol/packet/mob_equipment.go
@@ -13,7 +13,7 @@ type MobEquipment struct {
 	EntityRuntimeID uint64
 	// NewItem is the new item held after sending the MobEquipment packet. The entity will be shown holding
 	// that item to the player it was sent to.
-	NewItem protocol.ItemInstance
+	NewItem protocol.NetworkItemStackDescriptor
 	// InventorySlot is the slot in the inventory that was held. This is the same as HotBarSlot, and only
 	// remains for backwards compatibility.
 	InventorySlot byte
@@ -32,7 +32,7 @@ func (*MobEquipment) ID() uint32 {
 
 func (pk *MobEquipment) Marshal(io protocol.IO) {
 	io.Varuint64(&pk.EntityRuntimeID)
-	io.ItemInstanceNew(&pk.NewItem)
+	protocol.Single(io, &pk.NewItem)
 	io.Uint8(&pk.InventorySlot)
 	io.Uint8(&pk.HotBarSlot)
 	io.Uint8(&pk.WindowID)

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -273,7 +273,7 @@ func (r *Reader) PlayerInventoryAction(x *UseItemTransactionData) {
 	r.BlockPos(&x.BlockPosition)
 	r.Varint32(&x.BlockFace)
 	r.Varint32(&x.HotBarSlot)
-	r.ItemInstance(&x.HeldItem)
+	Single(r, &x.HeldItem)
 	r.Vec3(&x.Position)
 	r.Vec3(&x.ClickedPosition)
 	r.Varuint32(&x.BlockRuntimeID)
@@ -485,11 +485,10 @@ func (r *Reader) ItemInstanceNew(i *ItemInstance) {
 	r.Bool(&hasNetID)
 
 	if hasNetID {
-		var empty uint32
-		r.Varuint32(&empty)
+		r.Varuint32(&i.StackNetworkIDVariant)
 		r.Varint32(&i.StackNetworkID)
 	} else {
-		i.StackNetworkID = 0
+		i.StackNetworkID, i.StackNetworkIDVariant = 0, 0
 	}
 
 	var runtimeID uint32

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -418,7 +418,7 @@ func (r *Reader) ItemInstance(i *ItemInstance) {
 	if x.NetworkID == 0 {
 		// The item was air, so there is no more data we should read for the item instance. After all, air
 		// items aren't really anything.
-		x.MetadataValue, x.Count, x.BlockRuntimeID, i.StackNetworkID = 0, 0, 0, 0
+		x.MetadataValue, x.Count, x.BlockRuntimeID, i.StackNetworkID, i.StackNetworkIDVariant = 0, 0, 0, 0, 0
 		x.NBTData, x.CanBePlacedOn, x.CanBreak = nil, nil, nil
 		return
 	}
@@ -432,7 +432,7 @@ func (r *Reader) ItemInstance(i *ItemInstance) {
 	if hasNetID {
 		r.Varint32(&i.StackNetworkID)
 	} else {
-		i.StackNetworkID = 0
+		i.StackNetworkID, i.StackNetworkIDVariant = 0, 0
 	}
 
 	r.Varint32(&x.BlockRuntimeID)

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -176,7 +176,7 @@ func (w *Writer) PlayerInventoryAction(x *UseItemTransactionData) {
 	w.BlockPos(&x.BlockPosition)
 	w.Varint32(&x.BlockFace)
 	w.Varint32(&x.HotBarSlot)
-	w.ItemInstance(&x.HeldItem)
+	Single(w, &x.HeldItem)
 	w.Vec3(&x.Position)
 	w.Vec3(&x.ClickedPosition)
 	w.Varuint32(&x.BlockRuntimeID)
@@ -382,8 +382,7 @@ func (w *Writer) ItemInstanceNew(i *ItemInstance) {
 	w.Bool(&hasNetID)
 
 	if hasNetID {
-		var zero uint32
-		w.Varuint32(&zero)
+		w.Varuint32(&i.StackNetworkIDVariant)
 		w.Varint32(&i.StackNetworkID)
 	}
 


### PR DESCRIPTION
Closed: this protocol fork is unnecessary. Upstream/master already has the shield `BlockingTick` and `ShieldID` support needed for Dragonfly, so this should not be reviewed or merged.