### PR TITLE
[Cursor Review] Reject malformed oversized packet batches during decode

### DIFF
--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -66,6 +66,7 @@ func NewDecoder(reader io.Reader) *Decoder {
 	return &Decoder{
 		r:                 reader,
 		buf:               make([]byte, 1024*1024*3),
+		header:            batch,
 		checkPacketLimit:  true,
 		disableEncryption: disableEncryption,
 	}
@@ -138,6 +139,9 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 	}
 
 	if decoder.decompress {
+		if len(data) == 0 {
+			return nil, fmt.Errorf("decompress batch: missing compression algorithm")
+		}
 		if data[0] == 0xff {
 			data = data[1:]
 		} else {
@@ -161,10 +165,16 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 		if err := protocol.Varuint32(b, &length); err != nil {
 			return nil, fmt.Errorf("decode batch: read packet length: %w", err)
 		}
+		if length == 0 {
+			return nil, fmt.Errorf("decode batch: empty packet")
+		}
+		if length > uint32(b.Len()) {
+			return nil, fmt.Errorf("decode batch: packet length %v exceeds remaining %v", length, b.Len())
+		}
+		if len(packets) >= maximumInBatch && decoder.checkPacketLimit {
+			return nil, fmt.Errorf("decode batch: number of packets exceeds max=%v", maximumInBatch)
+		}
 		packets = append(packets, b.Next(int(length)))
-	}
-	if len(packets) > maximumInBatch && decoder.checkPacketLimit {
-		return nil, fmt.Errorf("decode batch: number of packets %v exceeds max=%v", len(packets), maximumInBatch)
 	}
 	return packets, nil
 }


### PR DESCRIPTION
Cursor review mirror of Sandertv/gophertunnel#427

Original: https://github.com/Sandertv/gophertunnel/pull/427

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core packet decoding and adds stricter validation, which could reject previously tolerated (but malformed) network data and affect interoperability if assumptions differ across peers.
> 
> **Overview**
> **Tightens `Decoder.Decode` validation for packet batches** to fail fast on malformed or potentially abusive input.
> 
> When compression is enabled, decoding now errors if the batch lacks a compression algorithm byte. While parsing the batch payload, it rejects zero-length packets, packet lengths that exceed remaining bytes, and batches that exceed `maximumInBatch` *during* iteration (instead of only after reading all packets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf107ea2b756a06d987f47e38a36920ed8a2ffa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->