### PR TITLE
Avoid protocol string marshal allocations

### DIFF
--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -33,7 +33,18 @@ func NewWriter(w interface {
 	io.Writer
 	io.ByteWriter
 }, shieldID int32) *Writer {
-	return &Writer{w: w, shieldID: shieldID}
+	writer := new(Writer)
+	writer.Reset(w, shieldID)
+	return writer
+}
+
+// Reset reuses w with a new underlying destination and shield ID.
+func (w *Writer) Reset(dst interface {
+	io.Writer
+	io.ByteWriter
+}, shieldID int32) {
+	w.w = dst
+	w.shieldID = shieldID
 }
 
 // Uint8 writes a uint8 to the underlying buffer.
@@ -55,14 +66,26 @@ func (w *Writer) Bool(x *bool) {
 func (w *Writer) StringUTF(x *string) {
 	l := int16(len(*x))
 	w.Int16(&l)
-	_, _ = w.w.Write([]byte(*x))
+	w.writeString(*x)
 }
 
 // String writes a string, prefixed with a varuint32, to the underlying buffer.
 func (w *Writer) String(x *string) {
 	l := uint32(len(*x))
 	w.Varuint32(&l)
-	_, _ = w.w.Write([]byte(*x))
+	w.writeString(*x)
+}
+
+type stringWriter interface {
+	WriteString(string) (int, error)
+}
+
+func (w *Writer) writeString(s string) {
+	if sw, ok := w.w.(stringWriter); ok {
+		_, _ = sw.WriteString(s)
+		return
+	}
+	_, _ = w.w.Write([]byte(s))
 }
 
 // ByteSlice writes a []byte, prefixed with a varuint32, to the underlying buffer.
@@ -344,7 +367,8 @@ func (w *Writer) ItemInstance(i *ItemInstance) {
 		internal.BufferPool.Put(buf)
 	}()
 
-	bufWriter := NewWriter(buf, w.shieldID)
+	var bufWriter Writer
+	bufWriter.Reset(buf, w.shieldID)
 
 	var length int16
 	if len(x.NBTData) != 0 {
@@ -358,8 +382,8 @@ func (w *Writer) ItemInstance(i *ItemInstance) {
 		bufWriter.Int16(&length)
 	}
 
-	FuncSliceUint32Length(bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
-	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBreak, bufWriter.StringUTF)
 
 	if x.NetworkID == bufWriter.shieldID {
 		bufWriter.Int64(&x.BlockingTick)
@@ -403,7 +427,8 @@ func (w *Writer) ItemInstanceNew(i *ItemInstance) {
 		internal.BufferPool.Put(buf)
 	}()
 
-	bufWriter := NewWriter(buf, w.shieldID)
+	var bufWriter Writer
+	bufWriter.Reset(buf, w.shieldID)
 
 	var length int16
 	if len(x.NBTData) != 0 {
@@ -417,8 +442,8 @@ func (w *Writer) ItemInstanceNew(i *ItemInstance) {
 		bufWriter.Int16(&length)
 	}
 
-	FuncSliceUint32Length(bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
-	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBreak, bufWriter.StringUTF)
 
 	if x.NetworkID == bufWriter.shieldID {
 		bufWriter.Int64(&x.BlockingTick)
@@ -447,7 +472,8 @@ func (w *Writer) Item(x *ItemStack) {
 		internal.BufferPool.Put(buf)
 	}()
 
-	bufWriter := NewWriter(buf, w.shieldID)
+	var bufWriter Writer
+	bufWriter.Reset(buf, w.shieldID)
 
 	var length int16
 	if len(x.NBTData) != 0 {
@@ -461,8 +487,8 @@ func (w *Writer) Item(x *ItemStack) {
 		bufWriter.Int16(&length)
 	}
 
-	FuncSliceUint32Length(bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
-	FuncSliceUint32Length(bufWriter, &x.CanBreak, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBePlacedOn, bufWriter.StringUTF)
+	FuncSliceUint32Length(&bufWriter, &x.CanBreak, bufWriter.StringUTF)
 
 	if x.NetworkID == bufWriter.shieldID {
 		bufWriter.Int64(&x.BlockingTick)


### PR DESCRIPTION
```go
func BenchmarkWriterStringBytesBuffer(b *testing.B) {
	var buf bytes.Buffer
	var writer Writer
	writer.Reset(&buf, 0)
	s := strings.Repeat("gophertunnel", 16)

	b.ReportAllocs()
	b.SetBytes(int64(len(s)))
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		buf.Reset()
		writer.String(&s)
	}
}
```

BenchmarkWriterStringBytesBuffer

Before: 41.42 ns/op, 192 B/op, 1 alloc/op
After:  12.68 ns/op,   0 B/op, 0 allocs/op
Delta: -69.40% sec/op, -100% B/op, -100% allocs/op
Speedup: 41.42 / 12.68 = ~3.27x faster
