### PR TITLE
Reduce packet encoder batch allocations

### DIFF
--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/sandertv/gophertunnel/minecraft/internal"
 )
@@ -87,16 +88,28 @@ func (encoder *Encoder) EnableCompression(compression Compression, threshold int
 // optionally encrypted.
 func (encoder *Encoder) Encode(packets [][]byte) error {
 	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	var compressedBuf *bytes.Buffer
 	defer func() {
 		// Reset the buffer, so we can return it to the buffer pool safely.
 		buf.Reset()
 		internal.BufferPool.Put(buf)
+		if compressedBuf != nil {
+			compressedBuf.Reset()
+			internal.BufferPool.Put(compressedBuf)
+		}
 	}()
 
-	l := make([]byte, 5)
+	compression := encoder.compression
+	_, _ = buf.Write(encoder.header)
+	if compression != nil {
+		_ = buf.WriteByte(0)
+	}
+	batchStart := buf.Len()
+
+	var l [5]byte
 	for _, packet := range packets {
 		// Each packet is prefixed with a varuint32 specifying the length of the packet.
-		if err := writeVaruint32(buf, uint32(len(packet)), l); err != nil {
+		if _, err := buf.Write(l[:putVaruint32(&l, uint32(len(packet)))]); err != nil {
 			return fmt.Errorf("encode batch: write packet length: %w", err)
 		}
 		if _, err := buf.Write(packet); err != nil {
@@ -105,24 +118,30 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	}
 
 	data := buf.Bytes()
-	prepend := encoder.header
+	if compression != nil {
+		batch := data[batchStart:]
+		if len(batch) < encoder.compressionThreshold {
+			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
+		} else {
+			compressed, err := compression.Compress(batch)
+			if err != nil {
+				return fmt.Errorf("compress batch: %w", err)
+			}
 
-	if compression := encoder.compression; compression != nil {
-		if len(data) < encoder.compressionThreshold {
-			compression = NopCompression
+			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
+			_, _ = compressedBuf.Write(encoder.header)
+			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
+			if _, err := compressedBuf.Write(compressed); err != nil {
+				return fmt.Errorf("compress batch: write compressed payload: %w", err)
+			}
+			data = compressedBuf.Bytes()
 		}
-		var err error
-		data, err = compression.Compress(data)
-		if err != nil {
-			return fmt.Errorf("compress batch: %w", err)
-		}
-		prepend = append(prepend, byte(compression.EncodeCompression()))
 	}
 
-	data = append(prepend, data...)
 	if encoder.encrypt != nil {
 		// If the encryption session is not nil, encryption is enabled, meaning we should encrypt the
 		// compressed data of this packet.
+		data = slices.Grow(data, 8)
 		data = encoder.encrypt.encrypt(data)
 	}
 	if _, err := encoder.w.Write(data); err != nil {
@@ -131,10 +150,9 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	return nil
 }
 
-// writeVaruint32 writes a uint32 to the destination buffer passed with a size of 1-5 bytes. It uses byte
-// slice b in order to prevent allocations.
-func writeVaruint32(dst io.Writer, x uint32, b []byte) error {
-	clear(b[:5])
+// putVaruint32 writes x to b with a size of 1-5 bytes and returns the number of
+// bytes written.
+func putVaruint32(b *[5]byte, x uint32) int {
 	i := 0
 	for x >= 0x80 {
 		b[i] = byte(x) | 0x80
@@ -142,6 +160,5 @@ func writeVaruint32(dst io.Writer, x uint32, b []byte) error {
 		x >>= 7
 	}
 	b[i] = byte(x)
-	_, err := dst.Write(b[:i+1])
-	return err
+	return i + 1
 }


### PR DESCRIPTION
## Changes

- Build the batch header directly into the encoder buffer instead of prepending it afterward.
- Reserve and fill the compression algorithm byte in-place for compressed batches.
- Use stack varuint scratch for packet length prefixes.
- Use a pooled output buffer for compressed payload framing.

## Performance

EncoderEncodeNoCompression:
Before: 1066.5 ns/op, 4.758 KiB/op, 2 allocs/op
After:   157.2 ns/op, 0 B/op,       0 allocs/op
Delta:  -85.26% sec/op, -100% B/op, -100% allocs/op
Speedup: ~6.8x faster

EncoderEncodeNopBelowThreshold:
Before: 1377.0 ns/op, 4.768 KiB/op, 3 allocs/op
After:   151.0 ns/op, 0 B/op,       0 allocs/op
Delta:  -89.03% sec/op, -100% B/op, -100% allocs/op
Speedup: ~9.1x faster

EncoderEncodeFlate:
Before: 25.11 µs/op, 741.5 B/op, 4 allocs/op
After:  23.56 µs/op, 373.0 B/op, 1 alloc/op
Delta: speed statistically same, -49.70% B/op, -75% allocs/op

EncoderEncodeSnappy:
Before: 6.058 µs/op, 5.330 KiB/op, 4 allocs/op
After:  5.959 µs/op, 4.752 KiB/op, 1 alloc/op
Delta: speed statistically same, -10.85% B/op, -75% allocs/op

Geomean:
Before: 3.866µs
After:  1.351µs
Delta:  -65.05%, ~2.9x faster

## Benchmark code

```go
type benchmarkWriter struct{ n int }

func (w *benchmarkWriter) Write(p []byte) (int, error) {
	w.n += len(p)
	return len(p), nil
}

func BenchmarkEncoderEncodeNoCompression(b *testing.B) {
	benchmarkEncoderEncode(b, nil, 0, benchmarkPackets())
}

func BenchmarkEncoderEncodeNopBelowThreshold(b *testing.B) {
	benchmarkEncoderEncode(b, FlateCompression, 1<<20, benchmarkPackets())
}

func BenchmarkEncoderEncodeFlate(b *testing.B) {
	benchmarkEncoderEncode(b, FlateCompression, 0, benchmarkPackets())
}

func BenchmarkEncoderEncodeSnappy(b *testing.B) {
	benchmarkEncoderEncode(b, SnappyCompression, 0, benchmarkPackets())
}

func benchmarkEncoderEncode(b *testing.B, compression Compression, threshold int, packets [][]byte) {
	var bytesPerBatch int64
	for _, pk := range packets {
		bytesPerBatch += int64(len(pk))
	}
	b.SetBytes(bytesPerBatch)
	b.ReportAllocs()

	w := new(benchmarkWriter)
	encoder := NewEncoder(w)
	if compression != nil {
		encoder.EnableCompression(compression, threshold)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if err := encoder.Encode(packets); err != nil {
			b.Fatal(err)
		}
	}
}

func benchmarkPackets() [][]byte {
	packets := make([][]byte, 8)
	for i := range packets {
		packet := make([]byte, 512)
		for j := range packet {
			packet[j] = byte(i + j)
		}
		packets[i] = packet
	}
	return packets
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches packet framing/compression/encryption boundaries in `Encoder.Encode`, so any off-by-one or threshold handling change could break wire compatibility. Changes are localized but affect all outgoing packets.
> 
> **Overview**
> **Optimizes outbound packet batching** by writing the batch header and (when enabled) the compression-algorithm byte directly into the main buffer instead of prepending/allocating later.
> 
> Compression handling is reworked to *only compress the batch payload* and, when compression is used, to frame the result using a pooled `compressedBuf`; below-threshold batches now flip the reserved algorithm byte to `NopCompression` in-place.
> 
> Replaces `writeVaruint32` (io.Writer-based, slice scratch) with stack-based `putVaruint32` and adds a small pre-grow (`slices.Grow`) before encryption to avoid extra allocations during `encrypt.encrypt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309b030cfe33af564619d416dc7c26f053e749a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->