### PR TITLE
Avoid extra Snappy batch encode allocation

### DIFF
--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/flate"
@@ -20,6 +21,11 @@ type Compression interface {
 	Compress(decompressed []byte) ([]byte, error)
 	// Decompress decompresses the given data and returns the decompressed data.
 	Decompress(compressed []byte, limit int) ([]byte, error)
+}
+
+type appendCompression interface {
+	CompressAppend(dst, decompressed []byte) ([]byte, error)
+	MaxCompressedLen(decompressedLen int) int
 }
 
 var (
@@ -161,6 +167,23 @@ func (snappyCompression) Compress(decompressed []byte) ([]byte, error) {
 	// EncodeSnappyBetter, which trades more CPU and retained scratch memory for a
 	// smaller output size.
 	return s2.EncodeSnappy(nil, decompressed), nil
+}
+
+func (snappyCompression) CompressAppend(dst, decompressed []byte) ([]byte, error) {
+	// Append into the caller-provided output buffer so Encoder can keep the
+	// batch header and compression ID in the same allocation as the payload.
+	n := s2.MaxEncodedLen(len(decompressed))
+	if n < 0 {
+		panic(s2.ErrTooLarge)
+	}
+	offset := len(dst)
+	dst = slices.Grow(dst, n)
+	encoded := s2.EncodeSnappy(dst[offset:offset:cap(dst)], decompressed)
+	return dst[:offset+len(encoded)], nil
+}
+
+func (snappyCompression) MaxCompressedLen(decompressedLen int) int {
+	return s2.MaxEncodedLen(decompressedLen)
 }
 
 // Decompress ...

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -123,18 +123,26 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		if len(batch) < encoder.compressionThreshold {
 			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
 		} else {
-			compressed, err := compression.Compress(batch)
-			if err != nil {
-				return fmt.Errorf("compress batch: %w", err)
-			}
-
+			data[len(encoder.header)] = byte(compression.EncodeCompression())
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
-			if _, err := compressedBuf.Write(compressed); err != nil {
-				return fmt.Errorf("compress batch: write compressed payload: %w", err)
+			var err error
+			if appender, ok := compression.(appendCompression); ok {
+				if n := appender.MaxCompressedLen(len(batch)); n > 0 {
+					compressedBuf.Grow(n)
+				}
+				dst := compressedBuf.Bytes()
+				data, err = appender.CompressAppend(dst, batch)
+			} else {
+				dst := compressedBuf.Bytes()
+				var compressed []byte
+				compressed, err = compression.Compress(batch)
+				data = append(dst, compressed...)
 			}
-			data = compressedBuf.Bytes()
+			if err != nil {
+				return fmt.Errorf("compress batch: %w", err)
+			}
 		}
 	}
 

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/internal"
 )
 
+const maxPooledEncoderBufferCap = 1 << 20
+
 // Encoder handles the encoding of Minecraft packets that are sent to an io.Writer. The packets are compressed
 // and optionally encoded before they are sent to the io.Writer.
 type Encoder struct {
@@ -94,8 +96,10 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		buf.Reset()
 		internal.BufferPool.Put(buf)
 		if compressedBuf != nil {
-			compressedBuf.Reset()
-			internal.BufferPool.Put(compressedBuf)
+			if compressedBuf.Cap() <= maxPooledEncoderBufferCap {
+				compressedBuf.Reset()
+				internal.BufferPool.Put(compressedBuf)
+			}
 		}
 	}()
 

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -95,11 +95,9 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		// Reset the buffer, so we can return it to the buffer pool safely.
 		buf.Reset()
 		internal.BufferPool.Put(buf)
-		if compressedBuf != nil {
-			if compressedBuf.Cap() <= maxPooledEncoderBufferCap {
-				compressedBuf.Reset()
-				internal.BufferPool.Put(compressedBuf)
-			}
+		if compressedBuf != nil && compressedBuf.Cap() <= maxPooledEncoderBufferCap {
+			compressedBuf.Reset()
+			internal.BufferPool.Put(compressedBuf)
 		}
 	}()
 

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -125,7 +125,6 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 		if len(batch) < encoder.compressionThreshold {
 			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
 		} else {
-			data[len(encoder.header)] = byte(compression.EncodeCompression())
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))


### PR DESCRIPTION
Avoid extra Snappy batch encode allocation (0 alloc, 1.50x faster)

## Changes
- Add a private append compression path for Snappy.
- Pre-grow the encoder output buffer so Snappy writes after the batch header/compression ID without allocating.
- Avoid returning oversized compressed buffers to the pool.

## Performance
BenchmarkEncoderEncodeSnappyTmp

Before: 2.449 µs/op, 3.001 KiB/op, 1 alloc/op
After:  1.630 µs/op, 0 B/op, 0 allocs/op
Delta: -33.46% sec/op, -100% B/op, -100% allocs/op
Speedup: 2.449 / 1.630 = ~1.50x faster

```text
                          │ /tmp/lunar-base-snappy.txt │    /tmp/lunar-current-snappy.txt     │
                          │           sec/op           │    sec/op     vs base                │
EncoderEncodeSnappyTmp-11                 2.449µ ± 46%   1.630µ ± 69%  -33.46% (p=0.023 n=10)

                          │ /tmp/lunar-base-snappy.txt │     /tmp/lunar-current-snappy.txt     │
                          │            B/op            │     B/op      vs base                 │
EncoderEncodeSnappyTmp-11                 3.001Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.000 n=10)

                          │ /tmp/lunar-base-snappy.txt │    /tmp/lunar-current-snappy.txt    │
                          │         allocs/op          │ allocs/op   vs base                 │
EncoderEncodeSnappyTmp-11                   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

## Benchmark code
```go
package packet

import (
	"bytes"
	"testing"
)

type benchmarkDiscardWriter struct{}

func (benchmarkDiscardWriter) Write(p []byte) (int, error) { return len(p), nil }

var benchmarkEncodePackets = [][]byte{
	append([]byte{0xfe, 0x01, 0x02, 0x03}, bytes.Repeat([]byte("gophertunnel snappy batch payload "), 32)...),
	append([]byte{0x91, 0x04, 0x05, 0x06}, bytes.Repeat([]byte("minecraft packet body "), 48)...),
	append([]byte{0xaa, 0x07, 0x08, 0x09}, bytes.Repeat([]byte("bedrock protocol data "), 40)...),
}

func BenchmarkEncoderEncodeSnappyTmp(b *testing.B) {
	encoder := NewEncoder(benchmarkDiscardWriter{})
	encoder.EnableCompression(SnappyCompression, 0)
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		if err := encoder.Encode(benchmarkEncodePackets); err != nil {
			b.Fatal(err)
		}
	}
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the packet encoding/compression write path to append compressed bytes directly into the output buffer; while intended to be output-equivalent, it touches core wire encoding and buffer/pool behavior so regressions would affect all Snappy-compressed packets.
> 
> **Overview**
> Optimizes batch encoding for Snappy by adding an internal `appendCompression` fast-path that can compress directly into a caller-provided destination slice, avoiding an extra allocation/copy after writing the batch header and compression ID.
> 
> Updates `Encoder.Encode` to pre-grow the output buffer using the compressor’s `MaxCompressedLen` and to use `CompressAppend` when available, and adds a cap (`maxPooledEncoderBufferCap`, 1 MiB) to avoid returning oversized compressed buffers to `internal.BufferPool`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37cd7d09e379e3a75ede7ae44d2b27296097725c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

