### PR TITLE
packet writing optimizations

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -201,6 +201,8 @@ var disconnectReasons = map[int32]string{
 	packet.DisconnectReasonDenyListed:                                    "You are in deny list.",
 }
 
+const maxPooledPacketBufferCap = 1 << 20
+
 // Conn represents a Minecraft (Bedrock Edition) connection over a specific net.Conn transport layer. Its
 // methods (Read, Write etc.) are safe to be called from multiple goroutines simultaneously, but ReadPacket
 // must not be called on multiple goroutines simultaneously.
@@ -258,16 +260,21 @@ type Conn struct {
 	deferredPackets []*packetData
 	readDeadline    <-chan time.Time
 
-	// sendMu protects bufferedSend/bufferedSendSpare.
+	// sendMu protects bufferedSend/bufferedSendSpare and packetWriter.
 	sendMu sync.Mutex
 	// encMu serializes encoder state changes and network writes (enc.Encode).
 	// Lock order (when both are needed): encMu → sendMu.
 	encMu sync.Mutex
-	// bufferedSend is a slice of byte slices containing packets that are 'written'. They are buffered until
-	// they are sent each 20th of a second.
-	bufferedSend      [][]byte
-	bufferedSendSpare [][]byte
-	hdr               *packet.Header
+	// directMu protects directSend between packet marshaling and encoder writes.
+	directMu sync.Mutex
+	// bufferedSend contains packets that are 'written'. They are buffered until they are sent each 20th
+	// of a second.
+	bufferedSend      packetQueue
+	bufferedSendSpare packetQueue
+	// directSend is reused by WritePacketDirect while directMu is held.
+	directSend   packetQueue
+	packetWriter protocol.IO
+	hdr          *packet.Header
 
 	// readyToLogin is a bool indicating if the connection is ready to login. This is used to ensure that the client
 	// has received the relevant network settings before the login sequence starts.
@@ -519,31 +526,96 @@ func (conn *Conn) WritePacket(pk packet.Packet) error {
 	return nil
 }
 
-// encodePacketsTo marshals the provided packet (including header) into one or more byte slices,
-// accounting for protocol conversions and invoking packetFunc callbacks. The resulting byte slices are
-// appended to dst. The appended slices are copies safe to retain beyond the call.
-func (conn *Conn) encodePacketsTo(dst *[][]byte, pks ...packet.Packet) {
-	buf := internal.BufferPool.Get().(*bytes.Buffer)
-	defer func() {
-		// Reset the buffer, so we can return it to the buffer pool safely.
-		buf.Reset()
-		internal.BufferPool.Put(buf)
-	}()
-
+// encodePacketsTo marshals the provided packet (including header) into one or more byte slices, accounting
+// for protocol conversions and invoking packetFunc callbacks. Encoded packet buffers appended to dst are
+// owned by dst and must be released after the queue is encoded.
+func (conn *Conn) encodePacketsTo(dst *packetQueue, pks ...packet.Packet) {
+	if _, ok := conn.proto.(proto); ok {
+		for _, pk := range pks {
+			conn.encodePacketTo(dst, pk)
+		}
+		return
+	}
 	for _, pk := range pks {
 		for _, converted := range conn.proto.ConvertFromLatest(pk, conn) {
-			buf.Reset()
-			conn.hdr.PacketID = converted.ID()
-			_ = conn.hdr.Write(buf)
-			l := buf.Len()
-
-			converted.Marshal(conn.proto.NewWriter(buf, conn.shieldID.Load()))
-			if conn.packetFunc != nil {
-				conn.packetFunc(*conn.hdr, buf.Bytes()[l:], conn.LocalAddr(), conn.RemoteAddr())
-			}
-			*dst = append(*dst, append([]byte(nil), buf.Bytes()...))
+			conn.encodePacketTo(dst, converted)
 		}
 	}
+}
+
+func (conn *Conn) encodePacketTo(dst *packetQueue, pk packet.Packet) {
+	buf := internal.BufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	conn.hdr.PacketID = pk.ID()
+	_ = conn.hdr.Write(buf)
+	l := buf.Len()
+
+	conn.marshalPacket(buf, pk)
+	if conn.packetFunc != nil {
+		conn.packetFunc(*conn.hdr, buf.Bytes()[l:], conn.LocalAddr(), conn.RemoteAddr())
+	}
+	dst.appendPooled(buf)
+}
+
+type resettablePacketWriter interface {
+	protocol.IO
+	Reset(interface {
+		io.Writer
+		io.ByteWriter
+	}, int32)
+}
+
+func (conn *Conn) marshalPacket(buf *bytes.Buffer, pk packet.Packet) {
+	shieldID := conn.shieldID.Load()
+	if writer, ok := conn.packetWriter.(resettablePacketWriter); ok {
+		writer.Reset(buf, shieldID)
+		pk.Marshal(writer)
+		return
+	}
+	writer := conn.proto.NewWriter(buf, shieldID)
+	pk.Marshal(writer)
+	if writer, ok := writer.(resettablePacketWriter); ok {
+		conn.packetWriter = writer
+	}
+}
+
+type packetQueue struct {
+	packets [][]byte
+	buffers []*bytes.Buffer
+}
+
+func (q *packetQueue) appendBorrowed(packet []byte) {
+	q.packets = append(q.packets, packet)
+	q.buffers = append(q.buffers, nil)
+}
+
+func (q *packetQueue) appendPooled(buf *bytes.Buffer) {
+	q.packets = append(q.packets, buf.Bytes())
+	q.buffers = append(q.buffers, buf)
+}
+
+func (q *packetQueue) reset() {
+	q.packets = q.packets[:0]
+	q.buffers = q.buffers[:0]
+}
+
+func (q *packetQueue) release() {
+	for i, buf := range q.buffers {
+		q.packets[i] = nil
+		q.buffers[i] = nil
+		if buf != nil {
+			releasePacketBuffer(buf)
+		}
+	}
+	q.reset()
+}
+
+func releasePacketBuffer(buf *bytes.Buffer) {
+	if buf.Cap() > maxPooledPacketBufferCap {
+		return
+	}
+	buf.Reset()
+	internal.BufferPool.Put(buf)
 }
 
 // WritePacketImmediate encodes the packets passed, queues them in the normal buffered send queue and flushes
@@ -572,22 +644,23 @@ func (conn *Conn) WritePacketDirect(pks ...packet.Packet) error {
 		return conn.closeErr("write packet direct")
 	default:
 	}
-	// Use a small stack-allocated buffer for the common case (usually 1 slice),
-	// allowing append to spill to heap only if more capacity is needed.
-	var stackBuf [4][]byte
-	immediate := stackBuf[:0]
-
+	conn.directMu.Lock()
 	conn.sendMu.Lock()
-	conn.encodePacketsTo(&immediate, pks...)
+	conn.directSend.reset()
+	conn.encodePacketsTo(&conn.directSend, pks...)
 	conn.sendMu.Unlock()
 
-	if len(immediate) > 0 {
+	var err error
+	if len(conn.directSend.packets) > 0 {
 		conn.encMu.Lock()
-		defer conn.encMu.Unlock()
-		if err := conn.enc.Encode(immediate); err != nil && !errors.Is(err, net.ErrClosed) {
-			// Should never happen.
-			panic(fmt.Errorf("error encoding packet batch: %w", err))
-		}
+		err = conn.enc.Encode(conn.directSend.packets)
+		conn.encMu.Unlock()
+	}
+	conn.directSend.release()
+	conn.directMu.Unlock()
+	if err != nil && !errors.Is(err, net.ErrClosed) {
+		// Should never happen.
+		panic(fmt.Errorf("error encoding packet batch: %w", err))
 	}
 	return nil
 }
@@ -651,7 +724,7 @@ func (conn *Conn) Write(b []byte) (n int, err error) {
 	conn.sendMu.Lock()
 	defer conn.sendMu.Unlock()
 
-	conn.bufferedSend = append(conn.bufferedSend, b)
+	conn.bufferedSend.appendBorrowed(b)
 	return len(b), nil
 }
 
@@ -707,7 +780,7 @@ func (conn *Conn) Flush() error {
 	defer conn.encMu.Unlock()
 
 	conn.sendMu.Lock()
-	if len(conn.bufferedSend) == 0 {
+	if len(conn.bufferedSend.packets) == 0 {
 		conn.sendMu.Unlock()
 		return nil
 	}
@@ -715,23 +788,20 @@ func (conn *Conn) Flush() error {
 	// Detach the current buffer and swap in the spare so writers can keep appending while we encode,
 	// without reallocating bufferedSend.
 	toSend := conn.bufferedSend
-	conn.bufferedSend = conn.bufferedSendSpare[:0]
-	conn.bufferedSendSpare = nil
+	conn.bufferedSend = conn.bufferedSendSpare
+	conn.bufferedSend.reset()
+	conn.bufferedSendSpare = packetQueue{}
 	conn.sendMu.Unlock()
 
-	if err := conn.enc.Encode(toSend); err != nil && !errors.Is(err, net.ErrClosed) {
+	err := conn.enc.Encode(toSend.packets)
+	toSend.release()
+	if err != nil && !errors.Is(err, net.ErrClosed) {
 		// Should never happen.
 		panic(fmt.Errorf("error encoding packet batch: %w", err))
 	}
 
-	// Clear out toSend so that re-using the slice after resetting its length to 0 doesn't keep references
-	// to packet payloads alive, causing an 'invisible' memory leak.
-	for i := range toSend {
-		toSend[i] = nil
-	}
-
 	conn.sendMu.Lock()
-	conn.bufferedSendSpare = toSend[:0]
+	conn.bufferedSendSpare = toSend
 	conn.sendMu.Unlock()
 	return nil
 }

--- a/minecraft/conn_bench_test.go
+++ b/minecraft/conn_bench_test.go
@@ -1,0 +1,100 @@
+package minecraft
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+type benchmarkConn struct{}
+
+func (benchmarkConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (benchmarkConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (benchmarkConn) Close() error                     { return nil }
+func (benchmarkConn) LocalAddr() net.Addr              { return benchmarkAddr("local") }
+func (benchmarkConn) RemoteAddr() net.Addr             { return benchmarkAddr("remote") }
+func (benchmarkConn) SetDeadline(time.Time) error      { return nil }
+func (benchmarkConn) SetReadDeadline(time.Time) error  { return nil }
+func (benchmarkConn) SetWriteDeadline(time.Time) error { return nil }
+
+type benchmarkAddr string
+
+func (a benchmarkAddr) Network() string { return string(a) }
+func (a benchmarkAddr) String() string  { return string(a) }
+
+func BenchmarkConnWritePacket(b *testing.B) {
+	conn := newConn(benchmarkConn{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultProtocol, 0, false)
+	pk := &packet.Unknown{
+		PacketID: packet.IDText,
+		Payload:  benchmarkPayload(512),
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := conn.WritePacket(pk); err != nil {
+			b.Fatal(err)
+		}
+		conn.bufferedSend.release()
+	}
+}
+
+func BenchmarkConnWritePacketFlush(b *testing.B) {
+	conn := newConn(benchmarkConn{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultProtocol, 0, false)
+	pk := &packet.Unknown{
+		PacketID: packet.IDText,
+		Payload:  benchmarkPayload(512),
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := conn.WritePacket(pk); err != nil {
+			b.Fatal(err)
+		}
+		if err := conn.Flush(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConnWritePacketDirect(b *testing.B) {
+	conn := newConn(benchmarkConn{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultProtocol, 0, false)
+	pk := &packet.Unknown{
+		PacketID: packet.IDText,
+		Payload:  benchmarkPayload(512),
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := conn.WritePacketDirect(pk); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConnWritePacketDirectBatch(b *testing.B) {
+	conn := newConn(benchmarkConn{}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultProtocol, 0, false)
+	payload := benchmarkPayload(512)
+	packets := make([]packet.Packet, 16)
+	for i := range packets {
+		packets[i] = &packet.Unknown{PacketID: packet.IDText, Payload: payload}
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := conn.WritePacketDirect(packets...); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchmarkPayload(n int) []byte {
+	payload := make([]byte, n)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}

--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -28,6 +28,10 @@ type appendCompression interface {
 	MaxCompressedLen(decompressedLen int) int
 }
 
+type writeCompression interface {
+	compressTo(dst io.Writer, decompressed []byte) error
+}
+
 var (
 	// NopCompression is an empty implementation that does not compress data.
 	NopCompression nopCompression
@@ -88,25 +92,35 @@ func (flateCompression) EncodeCompression() uint16 {
 }
 
 // Compress ...
-func (flateCompression) Compress(decompressed []byte) ([]byte, error) {
+func (c flateCompression) Compress(decompressed []byte) ([]byte, error) {
 	compressed := internal.BufferPool.Get().(*bytes.Buffer)
-	w := flateCompressPool.Get().(*flate.Writer)
-
 	defer func() {
 		// Reset the buffer, so we can return it to the buffer pool safely.
 		compressed.Reset()
 		internal.BufferPool.Put(compressed)
+	}()
+
+	if err := c.compressTo(compressed, decompressed); err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), compressed.Bytes()...), nil
+}
+
+func (flateCompression) compressTo(dst io.Writer, decompressed []byte) error {
+	w := flateCompressPool.Get().(*flate.Writer)
+	defer func() {
+		w.Reset(io.Discard)
 		flateCompressPool.Put(w)
 	}()
 
-	w.Reset(compressed)
+	w.Reset(dst)
 	if _, err := w.Write(decompressed); err != nil {
-		return nil, fmt.Errorf("compress flate: %w", err)
+		return fmt.Errorf("compress flate: %w", err)
 	}
 	if err := w.Close(); err != nil {
-		return nil, fmt.Errorf("close flate writer: %w", err)
+		return fmt.Errorf("close flate writer: %w", err)
 	}
-	return append([]byte(nil), compressed.Bytes()...), nil
+	return nil
 }
 
 // Decompress ...

--- a/minecraft/protocol/packet/compression_test.go
+++ b/minecraft/protocol/packet/compression_test.go
@@ -1,0 +1,27 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFlateCompressionCompressTo(t *testing.T) {
+	payload := bytes.Repeat([]byte("minecraft-packet-data:"), 512)
+	prefix := []byte{0xfe, 0x01, 0x02}
+	buf := bytes.NewBuffer(append([]byte(nil), prefix...))
+
+	if err := FlateCompression.compressTo(buf, payload); err != nil {
+		t.Fatal(err)
+	}
+	compressed := buf.Bytes()
+	if !bytes.Equal(compressed[:len(prefix)], prefix) {
+		t.Fatalf("prefix mismatch: got %#v, want %#v", compressed[:len(prefix)], prefix)
+	}
+	decompressed, err := FlateCompression.Decompress(compressed[len(prefix):], len(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(decompressed, payload) {
+		t.Fatal("decompressed payload mismatch")
+	}
+}

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -129,7 +129,10 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 			_, _ = compressedBuf.Write(encoder.header)
 			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
 			var err error
-			if appender, ok := compression.(appendCompression); ok {
+			if writer, ok := compression.(writeCompression); ok {
+				err = writer.compressTo(compressedBuf, batch)
+				data = compressedBuf.Bytes()
+			} else if appender, ok := compression.(appendCompression); ok {
 				if n := appender.MaxCompressedLen(len(batch)); n > 0 {
 					compressedBuf.Grow(n)
 				}

--- a/minecraft/protocol/packet/encoder_bench_test.go
+++ b/minecraft/protocol/packet/encoder_bench_test.go
@@ -1,0 +1,73 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkEncoderEncodeFlate(b *testing.B) {
+	benchmarkEncoderEncode(b, FlateCompression)
+}
+
+func BenchmarkEncoderEncodeSnappy(b *testing.B) {
+	benchmarkEncoderEncode(b, SnappyCompression)
+}
+
+func BenchmarkFlateCompressionCompress(b *testing.B) {
+	payload := benchmarkPayload(8192)
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	for b.Loop() {
+		compressed, err := FlateCompression.Compress(payload)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(compressed) == 0 {
+			b.Fatal("empty compressed payload")
+		}
+	}
+}
+
+func benchmarkEncoderEncode(b *testing.B, compression Compression) {
+	var out bytes.Buffer
+	encoder := NewEncoder(&out)
+	encoder.EnableCompression(compression, 0)
+	packets := benchmarkPackets(16, 512)
+
+	var batchBytes int64
+	for _, pk := range packets {
+		batchBytes += int64(len(pk))
+	}
+	b.SetBytes(batchBytes)
+	b.ReportAllocs()
+	for b.Loop() {
+		out.Reset()
+		if err := encoder.Encode(packets); err != nil {
+			b.Fatal(err)
+		}
+		if out.Len() == 0 {
+			b.Fatal("empty encoded batch")
+		}
+	}
+}
+
+func benchmarkPackets(count, size int) [][]byte {
+	packets := make([][]byte, count)
+	for i := range packets {
+		pk := make([]byte, size)
+		for j := range pk {
+			pk[j] = byte(i + j)
+		}
+		packets[i] = pk
+	}
+	return packets
+}
+
+func benchmarkPayload(n int) []byte {
+	payload := make([]byte, n)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	return payload
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core send/flush/encode paths and buffer ownership; behavior should match prior logic but regressions could affect ordering, memory, or wire format under edge cases.
> 
> **Overview**
> This PR speeds up **outbound packet encoding** on `Conn` and in the **batch encoder** by cutting allocations and improving buffer lifecycle management.
> 
> **`Conn`** now queues sends with a **`packetQueue`** that tracks pooled `bytes.Buffer` instances alongside packet slices, **releases** them after flush/encode, and **skips returning** oversized buffers to the pool (1 MiB cap). Encoding no longer copies every packet to a new `[]byte`; marshaling can **reuse** a resettable protocol writer, and **`WritePacketDirect`** uses a dedicated queue plus **`directMu`** instead of a stack buffer. **`Flush`** swaps full/spare queues and calls **`release()`** on the batch being encoded.
> 
> **Compression/encoding**: **Flate** can stream into an existing buffer via **`compressTo`**, which **`Encoder`** prefers (like Snappy’s append path). **`Conn`** benchmarks and encoder/compression benchmarks plus a **`compressTo`** test document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9fc70e51b6e4135d81ca1e6a19f5f9145f4bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->