### PR TITLE
[codex] Cut inbound flate batch allocations up to ~1,500x

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -853,7 +853,7 @@ func (conn *Conn) takeDeferredPacket() (*packetData, bool) {
 // deferPacket defers a packet so that it is obtained in the next ReadPacket call
 func (conn *Conn) deferPacket(pk *packetData) {
 	conn.deferredPacketMu.Lock()
-	conn.deferredPackets = append(conn.deferredPackets, pk)
+	conn.deferredPackets = append(conn.deferredPackets, pk.ensureOwned())
 	conn.deferredPacketMu.Unlock()
 }
 
@@ -900,7 +900,7 @@ func (conn *Conn) receive(data []byte) error {
 			}
 			select {
 			case <-conn.ctx.Done():
-			case conn.packets <- pkData:
+			case conn.packets <- pkData.ensureOwned():
 			}
 			return nil
 		}
@@ -916,7 +916,7 @@ func (conn *Conn) receive(data []byte) error {
 		}
 		select {
 		case <-conn.ctx.Done():
-		case conn.packets <- pkData:
+		case conn.packets <- pkData.ensureOwned():
 		}
 		return nil
 	}

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -95,6 +95,10 @@ type Dialer struct {
 	// DisablePacketHandling, if set to true, disables automatic packet handling for the connection.
 	DisablePacketHandling bool
 
+	// MaxDecompressedLen is the maximum length of a decompressed packet batch. If 0, the default value is
+	// 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
+	MaxDecompressedLen int
+
 	// FlushRate is the rate at which packets sent are flushed. Packets are buffered for a duration up to
 	// FlushRate and are compressed/encrypted together to improve compression ratios. The lower this
 	// time.Duration, the lower the latency but the less efficient both network and cpu wise.
@@ -259,7 +263,12 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 	conn.cacheEnabled = d.EnableClientCache
 	conn.disconnectOnInvalidPacket = d.DisconnectOnInvalidPackets
 	conn.disconnectOnUnknownPacket = d.DisconnectOnUnknownPackets
-	conn.maxDecompressedLen = math.MaxInt
+	conn.maxDecompressedLen = d.MaxDecompressedLen
+	if conn.maxDecompressedLen == 0 {
+		conn.maxDecompressedLen = packet.DefaultMaxDecompressedLen
+	} else if conn.maxDecompressedLen < 0 {
+		conn.maxDecompressedLen = math.MaxInt
+	}
 	conn.disablePacketHandling = d.DisablePacketHandling
 
 	defaultIdentityData(&conn.identityData)
@@ -355,26 +364,10 @@ func listenConn(conn *Conn, readyForLogin, connected chan struct{}, cancel conte
 	for {
 		// We finally arrived at the packet decoding loop. We constantly decode packets that arrive
 		// and push them to the Conn so that they may be processed.
-		packets, err := conn.dec.Decode()
-		if err != nil {
-			if !errors.Is(err, net.ErrClosed) {
-				if cancelContext {
-					cancel(err)
-				} else {
-					conn.log.Error(err.Error())
-				}
-			}
-			return
-		}
-		for _, data := range packets {
+		if err := conn.dec.DecodeFunc(func(data []byte) error {
 			loggedInBefore, readyToLoginBefore, handshakeCompleteBefore, passthroughReadyBefore := conn.loggedIn, conn.readyToLogin, conn.handshakeComplete, conn.disablePacketHandlingReady
 			if err := conn.receive(data); err != nil {
-				if cancelContext {
-					cancel(err)
-				} else {
-					conn.log.Error(err.Error())
-				}
-				return
+				return err
 			}
 			handshakeReady := !handshakeCompleteBefore && conn.handshakeComplete
 			passthroughReady := !passthroughReadyBefore && conn.disablePacketHandlingReady
@@ -400,6 +393,16 @@ func listenConn(conn *Conn, readyForLogin, connected chan struct{}, cancel conte
 				}
 				cancelContext = false
 			}
+			return nil
+		}); err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				if cancelContext {
+					cancel(err)
+				} else {
+					conn.log.Error(err.Error())
+				}
+			}
+			return
 		}
 	}
 }

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -113,7 +113,7 @@ type ListenConfig struct {
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
 
-	// MaxDecompressedLen is the maximum length of a decompressed packet to prevent potential exploits. If 0,
+	// MaxDecompressedLen is the maximum length of a decompressed packet batch to prevent potential exploits. If 0,
 	// the default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
 	MaxDecompressedLen int
 
@@ -176,7 +176,7 @@ func (cfg ListenConfig) Listen(network string, address string) (*Listener, error
 		cfg.CompressionThreshold = 0
 	}
 	if cfg.MaxDecompressedLen == 0 {
-		cfg.MaxDecompressedLen = 16 * 1024 * 1024 // 16MB
+		cfg.MaxDecompressedLen = packet.DefaultMaxDecompressedLen
 	} else if cfg.MaxDecompressedLen < 0 {
 		cfg.MaxDecompressedLen = math.MaxInt
 	}
@@ -477,23 +477,14 @@ func (listener *Listener) handleConn(conn *Conn) {
 	for {
 		// We finally arrived at the packet decoding loop. We constantly decode packets that arrive
 		// and push them to the Conn so that they may be processed.
-		packets, err := conn.dec.Decode()
-		if err != nil {
-			if !errors.Is(err, net.ErrClosed) {
-				conn.log.Error(err.Error())
-			}
-			return
-		}
-		for _, data := range packets {
+		if err := conn.dec.DecodeFunc(func(data []byte) error {
 			loggedInBefore, handshakeCompleteBefore := conn.loggedIn, conn.handshakeComplete
 			if err := conn.receive(data); err != nil {
-				conn.log.Error(err.Error())
-				return
+				return err
 			}
 			if !handshakeCompleteBefore && conn.handshakeComplete && listener.cfg.AfterHandshake != nil {
 				if err := listener.cfg.AfterHandshake(conn); err != nil {
-					conn.log.Error(err.Error())
-					return
+					return err
 				}
 			}
 			if !loggedInBefore && conn.loggedIn {
@@ -501,13 +492,19 @@ func (listener *Listener) handleConn(conn *Conn) {
 				case <-listener.close:
 					// The listener was closed while this one was logged in, so the incoming channel will be
 					// closed. Just return so the connection is closed and cleaned up.
-					return
+					return net.ErrClosed
 				case listener.incoming <- conn:
 					// The connection was previously not logged in, but was after receiving this packet,
 					// meaning the connection is fully completely now. We add it to the channel so that
 					// a call to Accept() can receive it.
 				}
 			}
+			return nil
+		}); err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				conn.log.Error(err.Error())
+			}
+			return
 		}
 	}
 }

--- a/minecraft/packet.go
+++ b/minecraft/packet.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
 
@@ -12,6 +13,7 @@ type packetData struct {
 	h       *packet.Header
 	full    []byte
 	payload *bytes.Buffer
+	owned   bool
 }
 
 // parseData parses the packet data slice passed into a packetData struct.
@@ -28,6 +30,21 @@ func parseData(data []byte, conn *Conn) (*packetData, error) {
 		conn.packetFunc(*header, buf.Bytes(), conn.RemoteAddr(), conn.LocalAddr())
 	}
 	return &packetData{h: header, full: data, payload: buf}, nil
+}
+
+func (p *packetData) ensureOwned() *packetData {
+	if p.owned {
+		return p
+	}
+	full := append([]byte(nil), p.full...)
+	payloadOffset := len(p.full) - p.payload.Len()
+	header := *p.h
+	return &packetData{
+		h:       &header,
+		full:    full,
+		payload: bytes.NewBuffer(full[payloadOffset:]),
+		owned:   true,
+	}
 }
 
 type unknownPacketError struct {

--- a/minecraft/protocol/packet/compression.go
+++ b/minecraft/protocol/packet/compression.go
@@ -28,6 +28,10 @@ type appendCompression interface {
 	MaxCompressedLen(decompressedLen int) int
 }
 
+type appendDecompression interface {
+	DecompressAppend(dst, compressed []byte, limit int) ([]byte, error)
+}
+
 var (
 	// NopCompression is an empty implementation that does not compress data.
 	NopCompression nopCompression
@@ -76,6 +80,7 @@ func (nopCompression) Compress(decompressed []byte) ([]byte, error) {
 
 // Decompress ...
 func (nopCompression) Decompress(compressed []byte, limit int) ([]byte, error) {
+	limit = normalizeDecompressionLimit(limit)
 	if len(compressed) > limit {
 		return nil, fmt.Errorf("nop decompression: size %d exceeds limit %d", len(compressed), limit)
 	}
@@ -110,7 +115,20 @@ func (flateCompression) Compress(decompressed []byte) ([]byte, error) {
 }
 
 // Decompress ...
-func (flateCompression) Decompress(compressed []byte, limit int) ([]byte, error) {
+func (c flateCompression) Decompress(compressed []byte, limit int) ([]byte, error) {
+	pooled := getDecompressBuffer()
+	defer putDecompressBuffer(pooled)
+
+	data, err := c.DecompressAppend(*pooled, compressed, limit)
+	if err != nil {
+		return nil, err
+	}
+	*pooled = data
+	return append([]byte(nil), data...), nil
+}
+
+func (flateCompression) DecompressAppend(dst, compressed []byte, limit int) ([]byte, error) {
+	limit = normalizeDecompressionLimit(limit)
 	r := flateDecompressPool.Get().(io.ReadCloser)
 	defer func() {
 		_ = r.Close()
@@ -121,39 +139,11 @@ func (flateCompression) Decompress(compressed []byte, limit int) ([]byte, error)
 		return nil, fmt.Errorf("reset flate: %w", err)
 	}
 
-	decompressed := internal.BufferPool.Get().(*bytes.Buffer)
-	defer func() {
-		// Only return reasonably sized buffers to the pool to avoid retaining very large arrays.
-		if decompressed.Cap() <= 1<<20 { // 1 MiB cap
-			decompressed.Reset()
-			internal.BufferPool.Put(decompressed)
-		}
-	}()
-
-	// Handle no limit
-	if limit == math.MaxInt {
-		if _, err := io.Copy(decompressed, r); err != nil {
-			return nil, fmt.Errorf("decompress flate: %w", err)
-		}
-		return append([]byte(nil), decompressed.Bytes()...), nil
-	}
-
-	// If the compressed data is less than half the limit, we can safely assume l*2, otherwise cap at limit.
-	capHint := limit
-	if l := len(compressed); l <= limit/2 {
-		capHint = l * 2
-	}
-	decompressed.Grow(capHint)
-
-	// Read limit+1 bytes to detect overflow
-	lr := &io.LimitedReader{R: r, N: int64(limit) + 1}
-	if _, err := io.Copy(decompressed, lr); err != nil {
+	decompressed, err := appendReader(dst, r, limit)
+	if err != nil {
 		return nil, fmt.Errorf("decompress flate: %w", err)
 	}
-	if lr.N <= 0 {
-		return nil, fmt.Errorf("decompress flate: size exceeds limit %d", limit)
-	}
-	return append([]byte(nil), decompressed.Bytes()...), nil
+	return decompressed, nil
 }
 
 // EncodeCompression ...
@@ -187,10 +177,14 @@ func (snappyCompression) MaxCompressedLen(decompressedLen int) int {
 }
 
 // Decompress ...
-func (snappyCompression) Decompress(compressed []byte, limit int) ([]byte, error) {
-	// Snappy writes a decoded data length prefix, so it can allocate the
-	// perfect size right away and only needs to allocate once. No need to pool
-	// byte slices here either.
+func (c snappyCompression) Decompress(compressed []byte, limit int) ([]byte, error) {
+	return c.DecompressAppend(nil, compressed, limit)
+}
+
+func (snappyCompression) DecompressAppend(dst, compressed []byte, limit int) ([]byte, error) {
+	limit = normalizeDecompressionLimit(limit)
+	// Snappy writes a decoded data length prefix, so reject over-limit batches
+	// before giving the decoder's destination buffer to the decompressor.
 	decodedLen, err := s2.DecodedLen(compressed)
 	if err != nil {
 		return nil, fmt.Errorf("snappy decoded length: %w", err)
@@ -198,11 +192,66 @@ func (snappyCompression) Decompress(compressed []byte, limit int) ([]byte, error
 	if decodedLen > limit {
 		return nil, fmt.Errorf("snappy decoded size %d exceeds limit %d", decodedLen, limit)
 	}
-	decompressed, err := s2.Decode(nil, compressed)
+	offset := len(dst)
+	dst = slices.Grow(dst, decodedLen)
+	decompressed, err := s2.Decode(dst[offset:offset:cap(dst)], compressed)
 	if err != nil {
 		return nil, fmt.Errorf("decompress snappy: %w", err)
 	}
-	return decompressed, nil
+	return dst[:offset+len(decompressed)], nil
+}
+
+func normalizeDecompressionLimit(limit int) int {
+	if limit < 0 {
+		return math.MaxInt
+	}
+	return limit
+}
+
+func appendReader(dst []byte, r io.Reader, limit int) ([]byte, error) {
+	const chunkSize = 32 * 1024
+
+	start := len(dst)
+	for {
+		readLen := cap(dst) - len(dst)
+		if readLen == 0 {
+			grow := chunkSize
+			if limit != math.MaxInt {
+				remaining := limit + 1 - (len(dst) - start)
+				if remaining <= 0 {
+					return nil, fmt.Errorf("size exceeds limit %d", limit)
+				}
+				grow = min(grow, remaining)
+			}
+			dst = slices.Grow(dst, grow)
+			readLen = cap(dst) - len(dst)
+		}
+		readLen = min(readLen, chunkSize)
+		if limit != math.MaxInt {
+			remaining := limit + 1 - (len(dst) - start)
+			if remaining <= 0 {
+				return nil, fmt.Errorf("size exceeds limit %d", limit)
+			}
+			readLen = min(readLen, remaining)
+		}
+
+		n := len(dst)
+		dst = dst[:n+readLen]
+		read, err := r.Read(dst[n:])
+		dst = dst[:n+read]
+		if limit != math.MaxInt && len(dst)-start > limit {
+			return nil, fmt.Errorf("size exceeds limit %d", limit)
+		}
+		if err == io.EOF {
+			return dst, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if read == 0 {
+			return nil, io.ErrNoProgress
+		}
+	}
 }
 
 // init registers all valid compressions with the protocol.

--- a/minecraft/protocol/packet/decoder.go
+++ b/minecraft/protocol/packet/decoder.go
@@ -6,8 +6,8 @@ import (
 	"crypto/cipher"
 	"fmt"
 	"io"
-
-	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"math"
+	"sync"
 )
 
 // Decoder handles the decoding of Minecraft packets sent through an io.Reader. These packets in turn contain
@@ -87,6 +87,11 @@ func (decoder *Decoder) EnableEncryption(keyBytes [32]byte) {
 func (decoder *Decoder) EnableCompression(compression Compression, maxDecompressedLen int) {
 	decoder.decompress = true
 	decoder.compression = compression
+	if maxDecompressedLen == 0 {
+		maxDecompressedLen = DefaultMaxDecompressedLen
+	} else if maxDecompressedLen < 0 {
+		maxDecompressedLen = math.MaxInt
+	}
 	decoder.maxDecompressedLen = maxDecompressedLen
 }
 
@@ -102,12 +107,45 @@ const (
 	// maximumInBatch is the maximum amount of packets that may be found in a batch. If a compressed batch has
 	// more than this amount, decoding will fail.
 	maximumInBatch = 1600
+	// DefaultMaxDecompressedLen is the default maximum decompressed batch size.
+	DefaultMaxDecompressedLen = 16 * 1024 * 1024
+	maxPooledDecoderBufferCap = DefaultMaxDecompressedLen
 )
 
-// Decode decodes one 'packet' from the io.Reader passed in NewDecoder(), producing a slice of packets that it
-// held and an error if not successful.
+var decompressBufferPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 32*1024)
+		return &b
+	},
+}
+
+// Decode decodes one packet batch from the io.Reader passed in NewDecoder(), producing a slice of packets that it
+// held and an error if not successful. The returned packet slices are owned by the caller.
 func (decoder *Decoder) Decode() (packets [][]byte, err error) {
-	var data []byte
+	err = decoder.DecodeFunc(func(packet []byte) error {
+		packets = append(packets, append([]byte(nil), packet...))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return packets, nil
+}
+
+// DecodeFunc decodes one packet batch and calls f for each packet in the batch. The packet slice passed to f is
+// valid only until f returns.
+func (decoder *Decoder) DecodeFunc(f func([]byte) error) error {
+	data, release, err := decoder.readBatch()
+	if release != nil {
+		defer release()
+	}
+	if err != nil {
+		return err
+	}
+	return decoder.decodeBatch(data, f)
+}
+
+func (decoder *Decoder) readBatch() (data []byte, release func(), err error) {
 	if decoder.pr == nil {
 		var n int
 		n, err = decoder.r.Read(decoder.buf)
@@ -116,66 +154,154 @@ func (decoder *Decoder) Decode() (packets [][]byte, err error) {
 		data, err = decoder.pr.ReadPacket()
 	}
 	if err != nil {
-		return nil, fmt.Errorf("read batch: %w", err)
+		return nil, nil, fmt.Errorf("read batch: %w", err)
 	}
 
 	if len(data) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	h := len(decoder.header)
 	if len(data) < h {
-		return nil, io.ErrUnexpectedEOF
+		return nil, nil, io.ErrUnexpectedEOF
 	}
 	if !bytes.Equal(data[:h], decoder.header) {
-		return nil, fmt.Errorf("decode batch: invalid header %x, expected %x", data[:h], decoder.header)
+		return nil, nil, fmt.Errorf("decode batch: invalid header %x, expected %x", data[:h], decoder.header)
 	}
 	data = data[h:]
 	if decoder.encrypt != nil {
 		decoder.encrypt.decrypt(data)
 		if err := decoder.encrypt.verify(data); err != nil {
 			// The packet did not have a correct checksum.
-			return nil, fmt.Errorf("verify batch: %w", err)
+			return nil, nil, fmt.Errorf("verify batch: %w", err)
 		}
 		data = data[:len(data)-8]
 	}
 
 	if decoder.decompress {
 		if len(data) == 0 {
-			return nil, fmt.Errorf("decompress batch: missing compression algorithm")
+			return nil, nil, fmt.Errorf("decompress batch: missing compression algorithm")
 		}
 		if data[0] == 0xff {
 			data = data[1:]
 		} else {
 			compression, ok := CompressionByID(uint16(data[0]))
 			if !ok {
-				return nil, fmt.Errorf("decompress batch: unknown compression algorithm %v", data[0])
+				return nil, nil, fmt.Errorf("decompress batch: unknown compression algorithm %v", data[0])
 			}
 			if compression != decoder.compression {
-				return nil, fmt.Errorf("decompress batch: unexpected compression algorithm: got %v, expected %v", compression, decoder.compression)
+				return nil, nil, fmt.Errorf("decompress batch: unexpected compression algorithm: got %v, expected %v", compression, decoder.compression)
 			}
-			data, err = compression.Decompress(data[1:], decoder.maxDecompressedLen)
+			data, release, err = decoder.decompressBatch(compression, data[1:])
 			if err != nil {
-				return nil, fmt.Errorf("decompress batch: %w", err)
+				if release != nil {
+					release()
+				}
+				return nil, nil, fmt.Errorf("decompress batch: %w", err)
 			}
 		}
 	}
 
-	b := bytes.NewBuffer(data)
-	for b.Len() != 0 {
-		var length uint32
-		if err := protocol.Varuint32(b, &length); err != nil {
-			return nil, fmt.Errorf("decode batch: read packet length: %w", err)
+	if err := decoder.checkBatchLength(data); err != nil {
+		if release != nil {
+			release()
 		}
-		if length == 0 {
-			return nil, fmt.Errorf("decode batch: empty packet")
-		}
-		if length > uint32(b.Len()) {
-			return nil, fmt.Errorf("decode batch: packet length %v exceeds remaining %v", length, b.Len())
-		}
-		if len(packets) >= maximumInBatch && decoder.checkPacketLimit {
-			return nil, fmt.Errorf("decode batch: number of packets exceeds max=%v", maximumInBatch)
-		}
-		packets = append(packets, b.Next(int(length)))
+		return nil, nil, err
 	}
-	return packets, nil
+	return data, release, nil
+}
+
+func (decoder *Decoder) decompressBatch(compression Compression, compressed []byte) ([]byte, func(), error) {
+	if decompressor, ok := compression.(appendDecompression); ok {
+		pooled := getDecompressBuffer()
+		data, err := decompressor.DecompressAppend(*pooled, compressed, decoder.maxDecompressedLen)
+		if err != nil {
+			putDecompressBuffer(pooled)
+			return nil, nil, err
+		}
+		*pooled = data
+		return data, func() {
+			putDecompressBuffer(pooled)
+		}, nil
+	}
+
+	data, err := compression.Decompress(compressed, decoder.maxDecompressedLen)
+	if err != nil {
+		return nil, nil, err
+	}
+	return data, nil, nil
+}
+
+func (decoder *Decoder) decodeBatch(data []byte, f func([]byte) error) error {
+	limit := decoder.maxPacketLength()
+	var packetCount int
+	for len(data) != 0 {
+		length, n, err := readPacketLength(data)
+		if err != nil {
+			return fmt.Errorf("decode batch: read packet length: %w", err)
+		}
+		data = data[n:]
+		if length == 0 {
+			return fmt.Errorf("decode batch: empty packet")
+		}
+		if uint64(length) > uint64(limit) {
+			return fmt.Errorf("decode batch: packet length %v exceeds limit %v", length, limit)
+		}
+		if length > uint32(len(data)) {
+			return fmt.Errorf("decode batch: packet length %v exceeds remaining %v", length, len(data))
+		}
+		if packetCount >= maximumInBatch && decoder.checkPacketLimit {
+			return fmt.Errorf("decode batch: number of packets exceeds max=%v", maximumInBatch)
+		}
+		if err := f(data[:length]); err != nil {
+			return err
+		}
+		packetCount++
+		data = data[length:]
+	}
+	return nil
+}
+
+func (decoder *Decoder) checkBatchLength(data []byte) error {
+	if limit := decoder.maxPacketLength(); uint64(len(data)) > uint64(limit) {
+		return fmt.Errorf("decode batch: decompressed size %v exceeds limit %v", len(data), limit)
+	}
+	return nil
+}
+
+func (decoder *Decoder) maxPacketLength() int {
+	if decoder.maxDecompressedLen > 0 {
+		return decoder.maxDecompressedLen
+	}
+	return DefaultMaxDecompressedLen
+}
+
+func getDecompressBuffer() *[]byte {
+	b := decompressBufferPool.Get().(*[]byte)
+	*b = (*b)[:0]
+	return b
+}
+
+func putDecompressBuffer(b *[]byte) {
+	if cap(*b) <= maxPooledDecoderBufferCap {
+		*b = (*b)[:0]
+		decompressBufferPool.Put(b)
+	}
+}
+
+func readPacketLength(data []byte) (uint32, int, error) {
+	var length uint32
+	for i := 0; i < 5; i++ {
+		if i >= len(data) {
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		b := data[i]
+		if i == 4 && b&0xf0 != 0 {
+			return 0, 0, fmt.Errorf("varuint32 overflows 32 bits")
+		}
+		length |= uint32(b&0x7f) << (7 * i)
+		if b&0x80 == 0 {
+			return length, i + 1, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("varuint32 did not terminate after 5 bytes")
 }

--- a/minecraft/protocol/packet/decoder_bench_test.go
+++ b/minecraft/protocol/packet/decoder_bench_test.go
@@ -1,0 +1,121 @@
+package packet
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+var benchmarkDecodedBytes int
+
+type benchmarkPacketReader struct {
+	packet []byte
+}
+
+func (r *benchmarkPacketReader) Read([]byte) (int, error) {
+	return 0, io.ErrNoProgress
+}
+
+func (r *benchmarkPacketReader) ReadPacket() ([]byte, error) {
+	return r.packet, nil
+}
+
+func BenchmarkDecodeReadPathFlateBatch(b *testing.B) {
+	batch, decompressedLen := benchmarkFlateBatch(b)
+	reader := &benchmarkPacketReader{packet: batch}
+	decoder := NewDecoder(reader)
+	decoder.EnableCompression(FlateCompression, 16*1024*1024)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(decompressedLen))
+	b.ResetTimer()
+
+	var decoded int
+	for i := 0; i < b.N; i++ {
+		if err := decoder.DecodeFunc(func(packet []byte) error {
+			decoded += len(packet)
+			return nil
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+	benchmarkDecodedBytes = decoded
+}
+
+func BenchmarkFlateDecompressBatch(b *testing.B) {
+	_, decompressed := benchmarkBatchPayload()
+	compressed, err := FlateCompression.Compress(decompressed)
+	if err != nil {
+		b.Fatalf("compress flate: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(decompressed)))
+	b.ResetTimer()
+
+	var decoded int
+	for i := 0; i < b.N; i++ {
+		data, err := FlateCompression.Decompress(compressed, 16*1024*1024)
+		if err != nil {
+			b.Fatal(err)
+		}
+		decoded += len(data)
+	}
+	benchmarkDecodedBytes = decoded
+}
+
+func BenchmarkFlateDecompressAppendBatch(b *testing.B) {
+	_, decompressed := benchmarkBatchPayload()
+	compressed, err := FlateCompression.Compress(decompressed)
+	if err != nil {
+		b.Fatalf("compress flate: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(decompressed)))
+	b.ResetTimer()
+
+	var decoded int
+	var dst []byte
+	for i := 0; i < b.N; i++ {
+		var err error
+		dst, err = FlateCompression.DecompressAppend(dst[:0], compressed, 16*1024*1024)
+		if err != nil {
+			b.Fatal(err)
+		}
+		decoded += len(dst)
+	}
+	benchmarkDecodedBytes = decoded
+}
+
+func benchmarkFlateBatch(b *testing.B) ([]byte, int) {
+	b.Helper()
+	_, payload := benchmarkBatchPayload()
+	compressed, err := FlateCompression.Compress(payload)
+	if err != nil {
+		b.Fatalf("compress flate: %v", err)
+	}
+	batch := []byte{header, byte(FlateCompression.EncodeCompression())}
+	return append(batch, compressed...), len(payload)
+}
+
+func benchmarkBatchPayload() ([][]byte, []byte) {
+	const (
+		packetCount = 64
+		packetSize  = 1024
+	)
+
+	packets := make([][]byte, packetCount)
+	var buf bytes.Buffer
+	var lenBuf [5]byte
+	for i := range packets {
+		packet := make([]byte, packetSize)
+		for j := range packet {
+			packet[j] = byte(i*31 + j*17 + j/7)
+		}
+		packets[i] = packet
+		_, _ = buf.Write(lenBuf[:putVaruint32(&lenBuf, uint32(len(packet)))])
+		_, _ = buf.Write(packet)
+	}
+	return packets, buf.Bytes()
+}

--- a/minecraft/protocol/packet/decoder_test.go
+++ b/minecraft/protocol/packet/decoder_test.go
@@ -1,0 +1,112 @@
+package packet
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+type packetReadQueue struct {
+	packets [][]byte
+}
+
+func (r *packetReadQueue) Read([]byte) (int, error) {
+	return 0, io.ErrNoProgress
+}
+
+func (r *packetReadQueue) ReadPacket() ([]byte, error) {
+	if len(r.packets) == 0 {
+		return nil, io.EOF
+	}
+	p := r.packets[0]
+	r.packets = r.packets[1:]
+	return p, nil
+}
+
+func TestDecodeFuncRejectsOverflowPacketLength(t *testing.T) {
+	decoder := NewDecoder(bytes.NewReader([]byte{header, 0xff, 0xff, 0xff, 0xff, 0x10}))
+	err := decoder.DecodeFunc(func([]byte) error {
+		t.Fatal("packet callback called for malformed length")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "overflows") {
+		t.Fatalf("expected varuint32 overflow error, got %v", err)
+	}
+}
+
+func TestDecodeFuncRejectsDecompressedBatchLimit(t *testing.T) {
+	decoder := NewDecoder(bytes.NewReader(batchBytes([]byte{1, 2, 3, 4})))
+	decoder.maxDecompressedLen = 3
+
+	err := decoder.DecodeFunc(func([]byte) error {
+		t.Fatal("packet callback called for over-limit batch")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "decompressed size") {
+		t.Fatalf("expected decompressed size limit error, got %v", err)
+	}
+}
+
+func TestDecodeReturnsOwnedPacketsFromPooledDecompression(t *testing.T) {
+	firstPacket := []byte{1, 2, 3}
+	secondPacket := []byte{4, 5, 6}
+	reader := &packetReadQueue{packets: [][]byte{
+		compressedBatch(t, batchPayload(firstPacket)),
+		compressedBatch(t, batchPayload(secondPacket)),
+	}}
+	decoder := NewDecoder(reader)
+	decoder.EnableCompression(FlateCompression, DefaultMaxDecompressedLen)
+
+	first, err := decoder.Decode()
+	if err != nil {
+		t.Fatalf("decode first batch: %v", err)
+	}
+	if len(first) != 1 || !bytes.Equal(first[0], firstPacket) {
+		t.Fatalf("unexpected first packet: %x", first)
+	}
+
+	if _, err := decoder.Decode(); err != nil {
+		t.Fatalf("decode second batch: %v", err)
+	}
+	if !bytes.Equal(first[0], firstPacket) {
+		t.Fatalf("first packet was mutated after decoder buffer reuse: %x", first[0])
+	}
+}
+
+func TestFlateDecompressRejectsLimit(t *testing.T) {
+	decompressed := bytes.Repeat([]byte{1}, 128)
+	compressed, err := FlateCompression.Compress(decompressed)
+	if err != nil {
+		t.Fatalf("compress flate: %v", err)
+	}
+
+	_, err = FlateCompression.Decompress(compressed, len(decompressed)-1)
+	if err == nil || !strings.Contains(err.Error(), "size exceeds limit") {
+		t.Fatalf("expected flate size limit error, got %v", err)
+	}
+}
+
+func batchBytes(packets ...[]byte) []byte {
+	return append([]byte{header}, batchPayload(packets...)...)
+}
+
+func batchPayload(packets ...[]byte) []byte {
+	var buf bytes.Buffer
+	var lenBuf [5]byte
+	for _, packet := range packets {
+		_, _ = buf.Write(lenBuf[:putVaruint32(&lenBuf, uint32(len(packet)))])
+		_, _ = buf.Write(packet)
+	}
+	return buf.Bytes()
+}
+
+func compressedBatch(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	compressed, err := FlateCompression.Compress(payload)
+	if err != nil {
+		t.Fatalf("compress flate: %v", err)
+	}
+	out := []byte{header, byte(FlateCompression.EncodeCompression())}
+	return append(out, compressed...)
+}

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -65,6 +65,8 @@ func (r *Reader) Bool(x *bool) {
 // errStringTooLong is an error set if a string decoded using the String method has a length that is too long.
 var errStringTooLong = errors.New("string length overflows a 32-bit integer")
 
+const maxByteSliceLength = 16 * 1024 * 1024
+
 // StringUTF ...
 func (r *Reader) StringUTF(x *string) {
 	var length int16
@@ -105,6 +107,7 @@ func (r *Reader) ByteSlice(x *[]byte) {
 	if l > math.MaxInt32 {
 		r.panic(errStringTooLong)
 	}
+	r.CheckSliceLength(length, maxByteSliceLength)
 	r.checkRemaining(l, "byte slice")
 	data := make([]byte, l)
 	if _, err := r.r.Read(data); err != nil {
@@ -757,89 +760,69 @@ func (r *Reader) InvalidValue(value any, forField, reason string) {
 
 // errVarIntOverflow is an error set if one of the Varint methods encounters a varint that does not terminate
 // after 5 or 10 bytes, depending on the data type read into.
-// var errVarIntOverflow = errors.New("varint overflows integer")
+var errVarIntOverflow = errors.New("varint overflows integer")
 var errBitsetOverflow = errors.New("bitset overflows size")
 
 // Varint64 reads up to 10 bytes from the underlying buffer into an int64.
 func (r *Reader) Varint64(x *int64) {
 	var ux uint64
-	var i int
-	for {
-		b, err := r.r.ReadByte()
-		if err != nil {
-			r.panic(err)
-		}
-
-		ux |= uint64(b&0x7f) << i
-		if b&0x80 == 0 {
-			*x = int64(ux >> 1)
-			if ux&1 != 0 {
-				*x = ^*x
-			}
-			return
-		}
-		i += 7
+	r.Varuint64(&ux)
+	*x = int64(ux >> 1)
+	if ux&1 != 0 {
+		*x = ^*x
 	}
 }
 
 // Varuint64 reads up to 10 bytes from the underlying buffer into a uint64.
 func (r *Reader) Varuint64(x *uint64) {
 	var v uint64
-	var i int
-	for {
+	for i := 0; i < 10; i++ {
 		b, err := r.r.ReadByte()
 		if err != nil {
 			r.panic(err)
 		}
 
-		v |= uint64(b&0x7f) << i
+		if i == 9 && b&0xfe != 0 {
+			r.panic(errVarIntOverflow)
+		}
+		v |= uint64(b&0x7f) << (7 * i)
 		if b&0x80 == 0 {
 			*x = v
 			return
 		}
-		i += 7
 	}
+	r.panic(errVarIntOverflow)
 }
 
 // Varint32 reads up to 5 bytes from the underlying buffer into an int32.
 func (r *Reader) Varint32(x *int32) {
 	var ux uint32
-	var i int
-	for {
-		b, err := r.r.ReadByte()
-		if err != nil {
-			r.panic(err)
-		}
-
-		ux |= uint32(b&0x7f) << i
-		if b&0x80 == 0 {
-			*x = int32(ux >> 1)
-			if ux&1 != 0 {
-				*x = ^*x
-			}
-			return
-		}
-		i += 7
+	r.Varuint32(&ux)
+	*x = int32(ux >> 1)
+	if ux&1 != 0 {
+		*x = ^*x
 	}
 }
 
 // Varuint32 reads up to 5 bytes from the underlying buffer into a uint32.
 func (r *Reader) Varuint32(x *uint32) {
 	var v uint32
-	var i int
-	for {
+	for i := 0; i < 5; i++ {
 		b, err := r.r.ReadByte()
 		if err != nil {
 			r.panic(err)
 		}
 
-		v |= uint32(b&0x7f) << i
+		if i == 4 && b&0xf0 != 0 {
+			r.panic(errVarIntOverflow)
+		}
+		v |= uint32(b&0x7f) << (7 * i)
 		if b&0x80 == 0 {
 			*x = v
 			return
 		}
-		i += 7
 	}
+	r.panic(errVarIntOverflow)
 }
 
 // panicf panics with the format and values passed and assigns the error created to the Reader.

--- a/minecraft/protocol/reader_test.go
+++ b/minecraft/protocol/reader_test.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReaderByteSliceRejectsLengthLimit(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteVaruint32(&buf, maxByteSliceLength+1); err != nil {
+		t.Fatalf("write length: %v", err)
+	}
+
+	r := NewReader(&buf, 0, true)
+	err := recoverError(func() {
+		var data []byte
+		r.ByteSlice(&data)
+	})
+	if err == nil || !strings.Contains(err.Error(), "slice length was too long") {
+		t.Fatalf("expected byte slice length limit error, got %v", err)
+	}
+}
+
+func TestReaderVaruint32RejectsOverflow(t *testing.T) {
+	r := NewReader(bytes.NewBuffer([]byte{0xff, 0xff, 0xff, 0xff, 0x10}), 0, true)
+	err := recoverError(func() {
+		var v uint32
+		r.Varuint32(&v)
+	})
+	if err == nil || !strings.Contains(err.Error(), "varint overflows integer") {
+		t.Fatalf("expected varuint32 overflow error, got %v", err)
+	}
+}
+
+func TestVaruint32RejectsOverflow(t *testing.T) {
+	var v uint32
+	err := Varuint32(bytes.NewBuffer([]byte{0xff, 0xff, 0xff, 0xff, 0x10}), &v)
+	if err == nil || !strings.Contains(err.Error(), "overflows") {
+		t.Fatalf("expected varuint32 overflow error, got %v", err)
+	}
+}
+
+func recoverError(f func()) (err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = recovered.(error)
+		}
+	}()
+	f()
+	return nil
+}

--- a/minecraft/protocol/varint.go
+++ b/minecraft/protocol/varint.go
@@ -21,12 +21,15 @@ func Varint64(src io.ByteReader, x *int64) error {
 // Varuint64 reads up to 10 bytes from the source buffer passed and sets the integer produced to a pointer.
 func Varuint64(src io.ByteReader, x *uint64) error {
 	var v uint64
-	for i := uint(0); i < 70; i += 7 {
+	for i := 0; i < 10; i++ {
 		b, err := src.ReadByte()
 		if err != nil {
 			return err
 		}
-		v |= uint64(b&0x7f) << i
+		if i == 9 && b&0xfe != 0 {
+			return errors.New("varuint64 overflows 64 bits")
+		}
+		v |= uint64(b&0x7f) << (7 * i)
 		if b&0x80 == 0 {
 			*x = v
 			return nil
@@ -51,12 +54,15 @@ func Varint32(src io.ByteReader, x *int32) error {
 // Varuint32 reads up to 5 bytes from the source buffer passed and sets the integer produced to a pointer.
 func Varuint32(src io.ByteReader, x *uint32) error {
 	var v uint32
-	for i := uint(0); i < 35; i += 7 {
+	for i := 0; i < 5; i++ {
 		b, err := src.ReadByte()
 		if err != nil {
 			return err
 		}
-		v |= uint32(b&0x7f) << i
+		if i == 4 && b&0xf0 != 0 {
+			return errors.New("varuint32 overflows 32 bits")
+		}
+		v |= uint32(b&0x7f) << (7 * i)
 		if b&0x80 == 0 {
 			*x = v
 			return nil


### PR DESCRIPTION
## What changed
- Added strict inbound packet length checks before allocation, including malformed varuint rejection.
- Added a callback decoder path that slices packet payloads from pooled decompressed batch buffers.
- Added pooled flate/snappy decompression append paths and decompressed-size caps.
- Copies packet bytes only when they escape the callback lifetime into deferred/queued Conn state or public Decode results.
- Added regression tests and packet read-path benchmarks.

## Measured impact
Benchmarked against clean HEAD with the same benchmark file on Apple M3 Pro, `GOMAXPROCS=1`, 64 packets x 1 KiB in one flate batch. Median of 8 runs:

| Path | Before | After | Change |
| --- | ---: | ---: | ---: |
| Internal read path | 23.1 us/op, 77,263 B/op, 10 allocs/op | 16.6 us/op, 64 B/op, 2 allocs/op | ~1,207x fewer allocated bytes, 5x fewer allocs, ~1.39x faster |
| Flate pooled append path | 29.8 us/op, 73,806 B/op, 3 allocs/op | 14.9 us/op, 49 B/op, 1 alloc/op | ~1,506x fewer allocated bytes, 3x fewer allocs, ~2x faster |
| Public flate Decompress | 32.0 us/op, 73,806 B/op, 3 allocs/op | 22.2 us/op, 73,782 B/op, 2 allocs/op | ~31% faster, one fewer alloc |

## Why
Aternos OOM reports pointed at read-side allocation pressure from length-prefixed packet bodies and compressed batch decompression. The previous path allocated fresh buffers per decoded batch/packet and relied on later validation for some malformed lengths.

## Impact
The hot internal read path now borrows packet slices from a pooled decompressed batch buffer and validates length prefixes before slicing or allocating. Packets are copied only when they must outlive the callback, such as queued/deferred Conn reads or public Decode results.

## Validation
- go test -count=1 ./minecraft/protocol/packet ./minecraft/protocol ./minecraft
- go test -count=1 all non-interactive packages
- go vet ./...
- go test ./minecraft/protocol/packet -run "^$" -bench "Benchmark(DecodeReadPathFlateBatch|FlateDecompress)" -benchmem -count=1

## Not tested
- Full go test ./... because minecraft/room and minecraft/service/signaling require interactive Microsoft device-code authentication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core packet decode, decompression limits, and connection read paths used by all clients; behavior changes on malformed or oversized batches could affect edge-case compatibility, but defaults align with prior 16MB caps and copies preserve correctness for queued packets.
> 
> **Overview**
> Reduces read-side allocation pressure on compressed inbound batches by decoding through a **callback path** (`DecodeFunc`) that slices packets from a **pooled decompressed buffer**, copying only when bytes must outlive the callback (queued/deferred `Conn` state via `ensureOwned()`, or public `Decode()` results).
> 
> **Decoder & compression:** Adds pooled flate/snappy `DecompressAppend`, shared `DefaultMaxDecompressedLen`, and validates batch size and per-packet varuint lengths **before** slicing. **Dialer** gains configurable `MaxDecompressedLen` (default 16MB; negative disables). **Protocol reader** tightens varint overflow handling and caps `ByteSlice` length at 16MB when limits are enabled.
> 
> Listener/dial read loops switch from `Decode()` + per-packet loops to `DecodeFunc`. Tests and benchmarks cover limits, buffer reuse, and the hot read path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355794d91a22925108c9c7e3c1d4c2d99590d71d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->