### PR TITLE
Add packet batch encode observer

### DIFF
--- a/minecraft/conn.go
+++ b/minecraft/conn.go
@@ -393,6 +393,14 @@ func (conn *Conn) ClientData() login.ClientData {
 	return conn.clientData
 }
 
+// SetPacketBatchFunc sets a callback called after each outbound packet batch is
+// encoded. Passing nil disables the callback.
+func (conn *Conn) SetPacketBatchFunc(f packet.BatchEncodeObserver) {
+	conn.encMu.Lock()
+	defer conn.encMu.Unlock()
+	conn.enc.SetBatchEncodeObserver(f)
+}
+
 // Authenticated returns true if the connection was authenticated through XBOX Live services.
 func (conn *Conn) Authenticated() bool {
 	return conn.IdentityData().XUID != ""

--- a/minecraft/dial.go
+++ b/minecraft/dial.go
@@ -69,6 +69,8 @@ type Dialer struct {
 	// Login packet. The function is called with the header of the packet and its raw payload, the address
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
+	// PacketBatchFunc is called after each outbound packet batch has been encoded.
+	PacketBatchFunc packet.BatchEncodeObserver
 
 	// DownloadResourcePack is called individually for every texture and behaviour pack sent by the connection when
 	// using Dialer.Dial(), and can be used to stop the pack from being downloaded. The function is called with the UUID
@@ -261,6 +263,7 @@ func (d Dialer) DialContext(ctx context.Context, network, address string) (conn 
 	conn.disconnectOnUnknownPacket = d.DisconnectOnUnknownPackets
 	conn.maxDecompressedLen = math.MaxInt
 	conn.disablePacketHandling = d.DisablePacketHandling
+	conn.SetPacketBatchFunc(d.PacketBatchFunc)
 
 	defaultIdentityData(&conn.identityData)
 	defaultClientData(address, conn.identityData.DisplayName, &conn.clientData)

--- a/minecraft/listener.go
+++ b/minecraft/listener.go
@@ -111,6 +111,8 @@ type ListenConfig struct {
 	// Login packet. The function is called with the header of the packet and its raw payload, the address
 	// from which the packet originated, and the destination address.
 	PacketFunc func(header packet.Header, payload []byte, src, dst net.Addr)
+	// PacketBatchFunc is called after each outbound packet batch has been encoded.
+	PacketBatchFunc packet.BatchEncodeObserver
 
 	// MaxDecompressedLen is the maximum length of a decompressed packet to prevent potential exploits. If 0,
 	// the default value is 16MB (16 * 1024 * 1024). Setting this to a negative integer disables the limit.
@@ -433,6 +435,7 @@ func (listener *Listener) createConn(netConn net.Conn) {
 	conn.pool = conn.proto.Packets(true)
 
 	conn.packetFunc = listener.cfg.PacketFunc
+	conn.SetPacketBatchFunc(listener.cfg.PacketBatchFunc)
 	conn.texturePacksRequired = listener.cfg.TexturePacksRequired
 	conn.forceDisableVibrantVisuals = listener.cfg.ForceDisableVibrantVisuals
 	conn.resourcePacks = packs

--- a/minecraft/protocol/packet/encoder.go
+++ b/minecraft/protocol/packet/encoder.go
@@ -13,6 +13,22 @@ import (
 
 const maxPooledEncoderBufferCap = 1 << 20
 
+// BatchEncodeStats describes one encoded packet batch.
+type BatchEncodeStats struct {
+	PacketCount      int
+	UncompressedLen  int
+	OutputLen        int
+	MaxCompressedLen int
+	BufferCap        int
+	CompressionID    uint16
+	Compressed       bool
+	BelowThreshold   bool
+	PooledBuffer     bool
+}
+
+// BatchEncodeObserver is called after a packet batch has been encoded.
+type BatchEncodeObserver func(BatchEncodeStats)
+
 // Encoder handles the encoding of Minecraft packets that are sent to an io.Writer. The packets are compressed
 // and optionally encoded before they are sent to the io.Writer.
 type Encoder struct {
@@ -27,6 +43,7 @@ type Encoder struct {
 	// disableEncryption indicates whether to prevent encryption from being enabled
 	// even if it is requested on handshake during login.
 	disableEncryption bool
+	observer          BatchEncodeObserver
 }
 
 // NewEncoder returns a new Encoder for the io.Writer passed. Each final packet produced by the Encoder is
@@ -86,6 +103,12 @@ func (encoder *Encoder) EnableCompression(compression Compression, threshold int
 	encoder.compressionThreshold = threshold
 }
 
+// SetBatchEncodeObserver sets an observer called with metadata for each encoded
+// packet batch. The observer should be fast and non-blocking.
+func (encoder *Encoder) SetBatchEncodeObserver(observer BatchEncodeObserver) {
+	encoder.observer = observer
+}
+
 // Encode encodes the packets passed. It writes all of them as a single packet which is  compressed and
 // optionally encrypted.
 func (encoder *Encoder) Encode(packets [][]byte) error {
@@ -102,6 +125,12 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	}()
 
 	compression := encoder.compression
+	observer := encoder.observer
+	var stats BatchEncodeStats
+	if observer != nil {
+		stats.PacketCount = len(packets)
+		stats.CompressionID = CompressionAlgorithmNone
+	}
 	_, _ = buf.Write(encoder.header)
 	if compression != nil {
 		_ = buf.WriteByte(0)
@@ -122,15 +151,28 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 	data := buf.Bytes()
 	if compression != nil {
 		batch := data[batchStart:]
+		if observer != nil {
+			stats.UncompressedLen = len(batch)
+		}
 		if len(batch) < encoder.compressionThreshold {
 			data[len(encoder.header)] = byte(NopCompression.EncodeCompression())
+			if observer != nil {
+				stats.BelowThreshold = true
+			}
 		} else {
 			compressedBuf = internal.BufferPool.Get().(*bytes.Buffer)
 			_, _ = compressedBuf.Write(encoder.header)
-			_ = compressedBuf.WriteByte(byte(compression.EncodeCompression()))
+			compressionID := compression.EncodeCompression()
+			if observer != nil {
+				stats.CompressionID = compressionID
+			}
+			_ = compressedBuf.WriteByte(byte(compressionID))
 			var err error
 			if appender, ok := compression.(appendCompression); ok {
 				if n := appender.MaxCompressedLen(len(batch)); n > 0 {
+					if observer != nil {
+						stats.MaxCompressedLen = n
+					}
 					compressedBuf.Grow(n)
 				}
 				dst := compressedBuf.Bytes()
@@ -144,14 +186,24 @@ func (encoder *Encoder) Encode(packets [][]byte) error {
 			if err != nil {
 				return fmt.Errorf("compress batch: %w", err)
 			}
+			if observer != nil {
+				stats.Compressed = true
+				stats.BufferCap = compressedBuf.Cap()
+				stats.PooledBuffer = stats.BufferCap <= maxPooledEncoderBufferCap
+			}
 		}
+	} else if observer != nil {
+		stats.UncompressedLen = len(data) - len(encoder.header)
 	}
-
 	if encoder.encrypt != nil {
 		// If the encryption session is not nil, encryption is enabled, meaning we should encrypt the
 		// compressed data of this packet.
 		data = slices.Grow(data, 8)
 		data = encoder.encrypt.encrypt(data)
+	}
+	if observer != nil {
+		stats.OutputLen = len(data) - len(encoder.header)
+		observer(stats)
 	}
 	if _, err := encoder.w.Write(data); err != nil {
 		return fmt.Errorf("write batch: %w", err)

--- a/minecraft/protocol/packet/encoder_test.go
+++ b/minecraft/protocol/packet/encoder_test.go
@@ -1,0 +1,90 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncoderBatchEncodeObserverBelowThreshold(t *testing.T) {
+	var out bytes.Buffer
+	enc := NewEncoder(&out)
+	enc.EnableCompression(SnappyCompression, 1024)
+
+	var stats BatchEncodeStats
+	enc.SetBatchEncodeObserver(func(s BatchEncodeStats) {
+		stats = s
+	})
+
+	payload := []byte{1, 2, 3}
+	if err := enc.Encode([][]byte{payload}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	if stats.PacketCount != 1 {
+		t.Fatalf("PacketCount = %d, want 1", stats.PacketCount)
+	}
+	if !stats.BelowThreshold {
+		t.Fatal("BelowThreshold = false, want true")
+	}
+	if stats.Compressed {
+		t.Fatal("Compressed = true, want false")
+	}
+	if stats.CompressionID != CompressionAlgorithmNone {
+		t.Fatalf("CompressionID = %d, want %d", stats.CompressionID, CompressionAlgorithmNone)
+	}
+	if stats.UncompressedLen == 0 || stats.OutputLen == 0 {
+		t.Fatalf("stats lengths were not populated: %+v", stats)
+	}
+}
+
+func TestEncoderBatchEncodeObserverCompressed(t *testing.T) {
+	var out bytes.Buffer
+	enc := NewEncoder(&out)
+	enc.EnableCompression(SnappyCompression, 1)
+
+	var stats BatchEncodeStats
+	enc.SetBatchEncodeObserver(func(s BatchEncodeStats) {
+		stats = s
+	})
+
+	payload := bytes.Repeat([]byte{7}, 2048)
+	if err := enc.Encode([][]byte{payload}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	if !stats.Compressed {
+		t.Fatal("Compressed = false, want true")
+	}
+	if stats.CompressionID != CompressionAlgorithmSnappy {
+		t.Fatalf("CompressionID = %d, want %d", stats.CompressionID, CompressionAlgorithmSnappy)
+	}
+	if stats.MaxCompressedLen == 0 {
+		t.Fatalf("MaxCompressedLen = 0, want populated stats: %+v", stats)
+	}
+	if stats.BufferCap == 0 || !stats.PooledBuffer {
+		t.Fatalf("pool stats not populated as expected: %+v", stats)
+	}
+	if stats.UncompressedLen == 0 || stats.OutputLen == 0 {
+		t.Fatalf("stats lengths were not populated: %+v", stats)
+	}
+}
+
+func TestEncoderBatchEncodeObserverOutputLenIncludesEncryptionChecksum(t *testing.T) {
+	var out bytes.Buffer
+	enc := NewEncoder(&out)
+	enc.EnableEncryption([32]byte{1})
+
+	var stats BatchEncodeStats
+	enc.SetBatchEncodeObserver(func(s BatchEncodeStats) {
+		stats = s
+	})
+
+	payload := []byte{1, 2, 3}
+	if err := enc.Encode([][]byte{payload}); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	if got, want := stats.OutputLen, stats.UncompressedLen+8; got != want {
+		t.Fatalf("OutputLen = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional outbound packet-batch encode observer so downstream services can measure real batch sizes without adding Prometheus or application-specific telemetry to gophertunnel.

The observer reports one small stats struct after each outbound batch is encoded, including:

- packet count
- uncompressed batch bytes
- encoded output bytes
- compression algorithm ID
- whether the batch was compressed or sent below-threshold
- worst-case compressed length requested by append-style compressors
- output buffer capacity and whether it stayed within the pooled encoder buffer cap

## Why

Lunar needs production data to choose an encoder buffer pool cap for Snappy/Flate batches. pprof can show allocation hot spots, but it does not provide a reliable p50/p95/p99 distribution of packet-batch sizes or tell us how often batches exceed the zero-allocation pooled buffer cap.

Putting the hook at the encoder layer gives exact data while keeping metric backend decisions outside the library.

## Implementation

- Adds `packet.BatchEncodeStats` and `packet.BatchEncodeObserver`.
- Adds `Encoder.SetBatchEncodeObserver`.
- Exposes `PacketBatchFunc` through `minecraft.ListenConfig` and `minecraft.Dialer`.
- Adds `Conn.SetPacketBatchFunc` for direct connection-level use.
- Adds encoder tests covering below-threshold and compressed paths.

## Testing

- `go test ./minecraft/protocol/packet ./minecraft`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional, nil-by-default callback on the encode path; no wire protocol or auth changes. Callers must keep observers fast to avoid blocking flushes.
> 
> **Overview**
> Adds an **optional outbound batch encode hook** so callers can observe each encoded write batch without baking in a specific metrics backend.
> 
> The encoder now exposes `BatchEncodeStats` and `BatchEncodeObserver`, invoked once per `Encode` with counts, uncompressed/output sizes, compression algorithm, below-threshold vs compressed paths, append-compressor max length, and pooled-buffer cap flags. **`OutputLen` is measured after encryption** (including the 8-byte checksum when enabled).
> 
> `Conn.SetPacketBatchFunc`, plus `Dialer.PacketBatchFunc` and `ListenConfig.PacketBatchFunc`, wire the observer through existing `encMu`-protected encoder setup. New encoder tests cover below-threshold, Snappy compression, and encrypted output length.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9358c2d21cc4d7a8d726e5f8ca08adf7d45c4839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->