### PR TITLE
[codex] Allow protocol schemas to load at runtime

### DIFF
--- a/minecraft/protocol/runtimeprotocol/protocol.go
+++ b/minecraft/protocol/runtimeprotocol/protocol.go
@@ -1,0 +1,138 @@
+// Package runtimeprotocol loads Mojang-style packet schemas into immutable
+// minecraft.Protocol implementations.
+package runtimeprotocol
+
+import (
+	"io/fs"
+
+	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+// Option changes how a Protocol is built from schemas.
+type Option func(*loadConfig)
+
+type loadConfig struct {
+	fallback minecraft.Protocol
+}
+
+// WithFallback sets the protocol used for readers, writers, conversions, and
+// packet constructors not covered by the loaded schemas.
+func WithFallback(fallback minecraft.Protocol) Option {
+	return func(c *loadConfig) {
+		c.fallback = fallback
+	}
+}
+
+// Protocol is an immutable minecraft.Protocol backed by loaded packet schemas.
+type Protocol struct {
+	id       int32
+	version  string
+	fallback minecraft.Protocol
+	packets  map[uint32]*packetSpec
+}
+
+var _ minecraft.Protocol = (*Protocol)(nil)
+
+// LoadMojangJSON loads all packet JSON files in fsys that match protocolID.
+// Packet schemas are overlaid onto the fallback protocol's packet pools.
+func LoadMojangJSON(fsys fs.FS, protocolID int32, opts ...Option) (*Protocol, error) {
+	cfg := loadConfig{fallback: minecraft.DefaultProtocol}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return loadSchemas(fsys, protocolID, cfg)
+}
+
+// ID returns the network protocol ID represented by p.
+func (p *Protocol) ID() int32 {
+	return p.id
+}
+
+// Ver returns the Minecraft version string represented by p.
+func (p *Protocol) Ver() string {
+	return p.version
+}
+
+// Packets returns the fallback packet pool with loaded dynamic packet schemas
+// overlaid by packet ID.
+func (p *Protocol) Packets(listener bool) packet.Pool {
+	pool := p.fallback.Packets(listener)
+	for id, spec := range p.packets {
+		id, spec := id, spec
+		pool[id] = func() packet.Packet {
+			return &DynamicPacket{PacketID: id, Values: map[string]any{}, spec: spec}
+		}
+	}
+	return pool
+}
+
+// NewReader returns a protocol reader for p. Runtime dynamic packets use the
+// same primitive IO implementation as the fallback protocol.
+func (p *Protocol) NewReader(r minecraft.ByteReader, shieldID int32, enableLimits bool) protocol.IO {
+	return p.fallback.NewReader(r, shieldID, enableLimits)
+}
+
+// NewWriter returns a protocol writer for p. Runtime dynamic packets use the
+// same primitive IO implementation as the fallback protocol.
+func (p *Protocol) NewWriter(w minecraft.ByteWriter, shieldID int32) protocol.IO {
+	return p.fallback.NewWriter(w, shieldID)
+}
+
+// ConvertToLatest keeps dynamic packets as-is and delegates compiled packets
+// to the fallback protocol.
+func (p *Protocol) ConvertToLatest(pk packet.Packet, conn *minecraft.Conn) []packet.Packet {
+	if _, ok := pk.(*DynamicPacket); ok {
+		return []packet.Packet{pk}
+	}
+	return p.fallback.ConvertToLatest(pk, conn)
+}
+
+// ConvertFromLatest keeps dynamic packets as-is and delegates compiled packets
+// to the fallback protocol.
+func (p *Protocol) ConvertFromLatest(pk packet.Packet, conn *minecraft.Conn) []packet.Packet {
+	if _, ok := pk.(*DynamicPacket); ok {
+		return []packet.Packet{pk}
+	}
+	return p.fallback.ConvertFromLatest(pk, conn)
+}
+
+// DynamicPacket is a schema-backed packet. Values contains decoded field values
+// keyed by the field names used in the source schema.
+type DynamicPacket struct {
+	PacketID uint32
+	Values   map[string]any
+
+	spec *packetSpec
+}
+
+var _ packet.Packet = (*DynamicPacket)(nil)
+
+// ID returns the packet ID for pk.
+func (pk *DynamicPacket) ID() uint32 {
+	return pk.PacketID
+}
+
+// Marshal reads or writes pk according to the schema it was created from.
+func (pk *DynamicPacket) Marshal(io protocol.IO) {
+	if pk.Values == nil {
+		pk.Values = map[string]any{}
+	}
+	if pk.spec == nil {
+		io.InvalidValue(pk.PacketID, "dynamic packet", "missing runtime packet schema")
+		return
+	}
+	if _, ok := io.(*protocol.Reader); ok {
+		pk.Values = pk.spec.decode(io)
+		return
+	}
+	pk.spec.encode(io, pk.Values)
+}
+
+// Variant is the decoded or to-be-encoded value of a schema oneOf field.
+type Variant struct {
+	Index uint32
+	Title string
+	Value map[string]any
+}

--- a/minecraft/protocol/runtimeprotocol/protocol_test.go
+++ b/minecraft/protocol/runtimeprotocol/protocol_test.go
@@ -1,0 +1,177 @@
+package runtimeprotocol_test
+
+import (
+	"bytes"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/runtimeprotocol"
+)
+
+func TestLoadMojangJSONOverlaysFallbackPool(t *testing.T) {
+	proto, err := runtimeprotocol.LoadMojangJSON(schemaFS(map[string]string{
+		"RequestNetworkSettingsPacket.json": `{
+			"x-minecraft-version": "1.26.30",
+			"x-protocol-version": 1001,
+			"title": "RequestNetworkSettingsPacket",
+			"type": "object",
+			"properties": {
+				"ClientNetworkVersion": {
+					"type": "integer",
+					"x-underlying-type": "int32",
+					"x-serialization-options": ["Big Endian"],
+					"x-ordinal-index": 0
+				}
+			},
+			"$metaProperties": {"[cereal:packet]": 193}
+		}`,
+	}), 1001, runtimeprotocol.WithFallback(minecraft.DefaultProtocol))
+	if err != nil {
+		t.Fatalf("LoadMojangJSON: %v", err)
+	}
+	if proto.ID() != 1001 {
+		t.Fatalf("protocol ID = %v, want 1001", proto.ID())
+	}
+	if proto.Ver() != "1.26.30" {
+		t.Fatalf("protocol version = %q, want 1.26.30", proto.Ver())
+	}
+
+	pk := proto.Packets(true)[packet.IDRequestNetworkSettings]()
+	dynamic, ok := pk.(*runtimeprotocol.DynamicPacket)
+	if !ok {
+		t.Fatalf("packet type = %T, want *runtimeprotocol.DynamicPacket", pk)
+	}
+
+	in := bytes.NewBuffer([]byte{0, 0, 3, 233})
+	dynamic.Marshal(proto.NewReader(in, 0, true))
+	if got := dynamic.Values["ClientNetworkVersion"]; got != int32(1001) {
+		t.Fatalf("decoded ClientNetworkVersion = %#v, want int32(1001)", got)
+	}
+
+	dynamic.Values = map[string]any{"ClientNetworkVersion": int32(1001)}
+	var out bytes.Buffer
+	dynamic.Marshal(proto.NewWriter(&out, 0))
+	if got, want := out.Bytes(), []byte{0, 0, 3, 233}; !bytes.Equal(got, want) {
+		t.Fatalf("encoded payload = %x, want %x", got, want)
+	}
+}
+
+func TestDynamicPacketHandlesOneOfVariants(t *testing.T) {
+	proto, err := runtimeprotocol.LoadMojangJSON(schemaFS(map[string]string{
+		"TextPacket.json": `{
+			"x-minecraft-version": "1.26.30",
+			"x-protocol-version": 1001,
+			"title": "TextPacket",
+			"type": "object",
+			"definitions": {
+				"message_only": {
+					"title": "MessageOnly",
+					"type": "object",
+					"properties": {
+						"Message Type": {
+							"type": "string",
+							"enum": ["raw", "tip"],
+							"x-underlying-type": "uint8",
+							"x-serialization-options": ["Enum-as-Value"],
+							"x-ordinal-index": 0
+						},
+						"Message": {"type": "string", "x-ordinal-index": 1}
+					}
+				},
+				"authored": {
+					"title": "AuthorAndMessage",
+					"type": "object",
+					"properties": {
+						"Author": {"type": "string", "x-ordinal-index": 0},
+						"Message": {"type": "string", "x-ordinal-index": 1}
+					}
+				}
+			},
+			"properties": {
+				"Localize?": {
+					"type": "boolean",
+					"x-underlying-type": "boolean",
+					"x-ordinal-index": 0
+				},
+				"Body": {
+					"oneOf": [
+						{"$ref": "#/definitions/message_only", "x-ordinal-index": 0},
+						{"$ref": "#/definitions/authored", "x-ordinal-index": 1}
+					],
+					"x-control-value-type": "uint8",
+					"x-ordinal-index": 1
+				}
+			},
+			"$metaProperties": {"[cereal:packet]": 9}
+		}`,
+	}), 1001, runtimeprotocol.WithFallback(minecraft.DefaultProtocol))
+	if err != nil {
+		t.Fatalf("LoadMojangJSON: %v", err)
+	}
+
+	pk := proto.Packets(false)[packet.IDText]().(*runtimeprotocol.DynamicPacket)
+	pk.Values = map[string]any{
+		"Localize?": false,
+		"Body": runtimeprotocol.Variant{
+			Index: 0,
+			Value: map[string]any{
+				"Message Type": "raw",
+				"Message":      "hello",
+			},
+		},
+	}
+	var out bytes.Buffer
+	pk.Marshal(proto.NewWriter(&out, 0))
+
+	var want bytes.Buffer
+	_ = want.WriteByte(0)
+	_ = want.WriteByte(0)
+	_ = want.WriteByte(0)
+	writeString(&want, "hello")
+	if !bytes.Equal(out.Bytes(), want.Bytes()) {
+		t.Fatalf("encoded payload = %x, want %x", out.Bytes(), want.Bytes())
+	}
+
+	decoded := proto.Packets(false)[packet.IDText]().(*runtimeprotocol.DynamicPacket)
+	decoded.Marshal(proto.NewReader(bytes.NewBuffer(out.Bytes()), 0, true))
+	if got := decoded.Values["Localize?"]; got != false {
+		t.Fatalf("decoded Localize? = %#v, want false", got)
+	}
+	body, ok := decoded.Values["Body"].(runtimeprotocol.Variant)
+	if !ok {
+		t.Fatalf("decoded Body type = %T, want runtimeprotocol.Variant", decoded.Values["Body"])
+	}
+	if body.Index != 0 {
+		t.Fatalf("decoded Body index = %v, want 0", body.Index)
+	}
+	if got := body.Value["Message"]; got != "hello" {
+		t.Fatalf("decoded Body.Message = %#v, want hello", got)
+	}
+	if got := body.Value["Message Type"]; got != "raw" {
+		t.Fatalf("decoded Body.Message Type = %#v, want raw", got)
+	}
+}
+
+func schemaFS(files map[string]string) fs.FS {
+	out := fstest.MapFS{}
+	for name, data := range files {
+		out[name] = &fstest.MapFile{Data: []byte(data)}
+	}
+	return out
+}
+
+func writeString(buf *bytes.Buffer, s string) {
+	writeVaruint32(buf, uint32(len(s)))
+	_, _ = buf.WriteString(s)
+}
+
+func writeVaruint32(buf *bytes.Buffer, x uint32) {
+	for x >= 0x80 {
+		_ = buf.WriteByte(byte(x) | 0x80)
+		x >>= 7
+	}
+	_ = buf.WriteByte(byte(x))
+}

--- a/minecraft/protocol/runtimeprotocol/schema.go
+++ b/minecraft/protocol/runtimeprotocol/schema.go
@@ -1,0 +1,286 @@
+package runtimeprotocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path"
+	"slices"
+	"strings"
+)
+
+type schemaDocument struct {
+	Title           string             `json:"title"`
+	MinecraftVer    string             `json:"x-minecraft-version"`
+	ProtocolVersion int32              `json:"x-protocol-version"`
+	Definitions     map[string]rawNode `json:"definitions"`
+	Properties      map[string]rawNode `json:"properties"`
+	Meta            map[string]any     `json:"$metaProperties"`
+}
+
+type rawNode struct {
+	Ref                  string             `json:"$ref"`
+	Title                string             `json:"title"`
+	Type                 string             `json:"type"`
+	Enum                 []string           `json:"enum"`
+	Properties           map[string]rawNode `json:"properties"`
+	Items                *rawNode           `json:"items"`
+	OneOf                []rawNode          `json:"oneOf"`
+	UnderlyingType       string             `json:"x-underlying-type"`
+	ControlValueType     string             `json:"x-control-value-type"`
+	SerializationOptions []string           `json:"x-serialization-options"`
+	Ordinal              *int               `json:"x-ordinal-index"`
+}
+
+type packetSpec struct {
+	id     uint32
+	title  string
+	fields []fieldSpec
+}
+
+func (s *packetSpec) decode(io interfaceIO) map[string]any {
+	values := make(map[string]any, len(s.fields))
+	decodeFields(io, s.fields, values)
+	return values
+}
+
+func (s *packetSpec) encode(io interfaceIO, values map[string]any) {
+	encodeFields(io, s.fields, values)
+}
+
+type interfaceIO = interface {
+	Uint16(*uint16)
+	Int16(*int16)
+	Uint32(*uint32)
+	Int32(*int32)
+	BEInt32(*int32)
+	Uint64(*uint64)
+	Int64(*int64)
+	Float32(*float32)
+	Float64(*float64)
+	Uint8(*uint8)
+	Int8(*int8)
+	Bool(*bool)
+	Varint64(*int64)
+	Varuint64(*uint64)
+	Varint32(*int32)
+	Varuint32(*uint32)
+	String(*string)
+	InvalidValue(any, string, string)
+}
+
+type fieldKind uint8
+
+const (
+	fieldScalar fieldKind = iota
+	fieldObject
+	fieldArray
+	fieldVariant
+)
+
+type fieldSpec struct {
+	name     string
+	kind     fieldKind
+	wire     wireType
+	enum     []string
+	fields   []fieldSpec
+	elem     *fieldSpec
+	variants []variantSpec
+}
+
+type variantSpec struct {
+	index  uint32
+	title  string
+	fields []fieldSpec
+}
+
+type compiler struct {
+	doc *schemaDocument
+}
+
+func loadSchemas(fsys fs.FS, protocolID int32, cfg loadConfig) (*Protocol, error) {
+	p := &Protocol{
+		id:       protocolID,
+		fallback: cfg.fallback,
+		packets:  map[uint32]*packetSpec{},
+	}
+	if p.fallback == nil {
+		return nil, fmt.Errorf("runtime protocol: fallback protocol is nil")
+	}
+
+	err := fs.WalkDir(fsys, ".", func(name string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || strings.ToLower(path.Ext(name)) != ".json" {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return err
+		}
+		var doc schemaDocument
+		dec := json.NewDecoder(strings.NewReader(string(data)))
+		dec.UseNumber()
+		if err := dec.Decode(&doc); err != nil {
+			return fmt.Errorf("decode %s: %w", name, err)
+		}
+		if doc.ProtocolVersion != protocolID {
+			return nil
+		}
+		id, ok, err := schemaPacketID(doc.Meta)
+		if err != nil {
+			return fmt.Errorf("packet ID in %s: %w", name, err)
+		}
+		if !ok {
+			return nil
+		}
+		spec, err := (&compiler{doc: &doc}).compilePacket(id)
+		if err != nil {
+			return fmt.Errorf("compile %s: %w", name, err)
+		}
+		p.packets[id] = spec
+		if p.version == "" {
+			p.version = doc.MinecraftVer
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if p.version == "" {
+		p.version = p.fallback.Ver()
+	}
+	return p, nil
+}
+
+func schemaPacketID(meta map[string]any) (uint32, bool, error) {
+	if meta == nil {
+		return 0, false, nil
+	}
+	value, ok := meta["[cereal:packet]"]
+	if !ok {
+		return 0, false, nil
+	}
+	id, err := toUint32(value)
+	if err != nil {
+		return 0, false, err
+	}
+	return id, true, nil
+}
+
+func (c *compiler) compilePacket(id uint32) (*packetSpec, error) {
+	fields, err := c.compileProperties(c.doc.Properties)
+	if err != nil {
+		return nil, err
+	}
+	return &packetSpec{id: id, title: c.doc.Title, fields: fields}, nil
+}
+
+func (c *compiler) compileProperties(properties map[string]rawNode) ([]fieldSpec, error) {
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		names = append(names, name)
+	}
+	slices.SortFunc(names, func(a, b string) int {
+		return ordinal(properties[a]) - ordinal(properties[b])
+	})
+
+	fields := make([]fieldSpec, 0, len(names))
+	for _, name := range names {
+		field, err := c.compileField(name, properties[name])
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, field)
+	}
+	return fields, nil
+}
+
+func (c *compiler) compileField(name string, node rawNode) (fieldSpec, error) {
+	if node.Ref != "" && len(node.OneOf) == 0 {
+		resolved, err := c.resolve(node.Ref)
+		if err != nil {
+			return fieldSpec{}, err
+		}
+		node = mergeNode(resolved, node)
+	}
+	if len(node.OneOf) != 0 {
+		wire, err := controlWire(node.ControlValueType)
+		if err != nil {
+			return fieldSpec{}, fmt.Errorf("%s: %w", name, err)
+		}
+		variants := make([]variantSpec, 0, len(node.OneOf))
+		for i, rawVariant := range node.OneOf {
+			index := uint32(i)
+			if rawVariant.Ordinal != nil {
+				index = uint32(*rawVariant.Ordinal)
+			}
+			resolved := rawVariant
+			if rawVariant.Ref != "" {
+				var err error
+				resolved, err = c.resolve(rawVariant.Ref)
+				if err != nil {
+					return fieldSpec{}, err
+				}
+			}
+			fields, err := c.compileProperties(resolved.Properties)
+			if err != nil {
+				return fieldSpec{}, err
+			}
+			variants = append(variants, variantSpec{index: index, title: resolved.Title, fields: fields})
+		}
+		return fieldSpec{name: name, kind: fieldVariant, wire: wire, variants: variants}, nil
+	}
+	if len(node.Properties) != 0 || node.Type == "object" {
+		fields, err := c.compileProperties(node.Properties)
+		if err != nil {
+			return fieldSpec{}, err
+		}
+		return fieldSpec{name: name, kind: fieldObject, fields: fields}, nil
+	}
+	if node.Type == "array" {
+		if node.Items == nil {
+			return fieldSpec{}, fmt.Errorf("%s: array schema missing items", name)
+		}
+		elem, err := c.compileField("", *node.Items)
+		if err != nil {
+			return fieldSpec{}, err
+		}
+		return fieldSpec{name: name, kind: fieldArray, elem: &elem}, nil
+	}
+	wire, err := scalarWire(node)
+	if err != nil {
+		return fieldSpec{}, fmt.Errorf("%s: %w", name, err)
+	}
+	var enum []string
+	if isEnumAsValue(node) {
+		enum = node.Enum
+	}
+	return fieldSpec{name: name, kind: fieldScalar, wire: wire, enum: enum}, nil
+}
+
+func (c *compiler) resolve(ref string) (rawNode, error) {
+	const prefix = "#/definitions/"
+	if !strings.HasPrefix(ref, prefix) {
+		return rawNode{}, fmt.Errorf("unsupported ref %q", ref)
+	}
+	key := strings.TrimPrefix(ref, prefix)
+	node, ok := c.doc.Definitions[key]
+	if !ok {
+		return rawNode{}, fmt.Errorf("unknown ref %q", ref)
+	}
+	return node, nil
+}
+
+func mergeNode(base, overlay rawNode) rawNode {
+	base.Ordinal = overlay.Ordinal
+	return base
+}
+
+func ordinal(node rawNode) int {
+	if node.Ordinal == nil {
+		return int(^uint(0) >> 1)
+	}
+	return *node.Ordinal
+}

--- a/minecraft/protocol/runtimeprotocol/wire.go
+++ b/minecraft/protocol/runtimeprotocol/wire.go
@@ -1,0 +1,566 @@
+package runtimeprotocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+)
+
+type wireType uint8
+
+const (
+	wireBool wireType = iota
+	wireString
+	wireUint8
+	wireInt8
+	wireUint16
+	wireInt16
+	wireUint32
+	wireInt32
+	wireBEInt32
+	wireVaruint32
+	wireVarint32
+	wireUint64
+	wireInt64
+	wireVaruint64
+	wireVarint64
+	wireFloat32
+	wireFloat64
+)
+
+func decodeFields(io interfaceIO, fields []fieldSpec, values map[string]any) {
+	for _, field := range fields {
+		values[field.name] = decodeField(io, field)
+	}
+}
+
+func decodeField(io interfaceIO, field fieldSpec) any {
+	switch field.kind {
+	case fieldScalar:
+		value := decodeScalar(io, field.wire)
+		if len(field.enum) != 0 {
+			return decodeEnum(io, field, value)
+		}
+		return value
+	case fieldObject:
+		values := make(map[string]any, len(field.fields))
+		decodeFields(io, field.fields, values)
+		return values
+	case fieldArray:
+		var count uint32
+		io.Varuint32(&count)
+		values := make([]any, count)
+		for i := range values {
+			values[i] = decodeField(io, *field.elem)
+		}
+		return values
+	case fieldVariant:
+		index := readControl(io, field.wire)
+		variant, ok := variantByIndex(field.variants, index)
+		if !ok {
+			io.InvalidValue(index, field.name, "unknown oneOf variant index")
+			return Variant{Index: index}
+		}
+		values := make(map[string]any, len(variant.fields))
+		decodeFields(io, variant.fields, values)
+		return Variant{Index: index, Title: variant.title, Value: values}
+	default:
+		io.InvalidValue(field.name, "runtime schema field", "unknown field kind")
+		return nil
+	}
+}
+
+func encodeFields(io interfaceIO, fields []fieldSpec, values map[string]any) {
+	for _, field := range fields {
+		encodeField(io, field, values[field.name])
+	}
+}
+
+func encodeField(io interfaceIO, field fieldSpec, value any) {
+	switch field.kind {
+	case fieldScalar:
+		if len(field.enum) != 0 {
+			value = encodeEnumValue(io, field, value)
+		}
+		encodeScalar(io, field.wire, value)
+	case fieldObject:
+		encodeFields(io, field.fields, asMap(value))
+	case fieldArray:
+		values := asSlice(value)
+		count := uint32(len(values))
+		io.Varuint32(&count)
+		for _, elem := range values {
+			encodeField(io, *field.elem, elem)
+		}
+	case fieldVariant:
+		variant := asVariant(value)
+		spec, ok := variantByIndex(field.variants, variant.Index)
+		if !ok {
+			io.InvalidValue(variant.Index, field.name, "unknown oneOf variant index")
+			return
+		}
+		writeControl(io, field.wire, variant.Index)
+		encodeFields(io, spec.fields, variant.Value)
+	default:
+		io.InvalidValue(field.name, "runtime schema field", "unknown field kind")
+	}
+}
+
+func scalarWire(node rawNode) (wireType, error) {
+	if isEnumAsValue(node) {
+		return integerWire(node.UnderlyingType, node.SerializationOptions)
+	}
+	switch node.Type {
+	case "boolean":
+		return wireBool, nil
+	case "string":
+		return wireString, nil
+	case "number":
+		switch node.UnderlyingType {
+		case "", "float32":
+			return wireFloat32, nil
+		case "float64":
+			return wireFloat64, nil
+		default:
+			return 0, fmt.Errorf("unsupported number wire type %q", node.UnderlyingType)
+		}
+	case "integer":
+		return integerWire(node.UnderlyingType, node.SerializationOptions)
+	default:
+		return 0, fmt.Errorf("unsupported schema type %q", node.Type)
+	}
+}
+
+func isEnumAsValue(node rawNode) bool {
+	return node.Type == "string" && node.UnderlyingType != "" && hasOption(node.SerializationOptions, "Enum-as-Value")
+}
+
+func controlWire(typ string) (wireType, error) {
+	switch typ {
+	case "", "uint32":
+		return wireVaruint32, nil
+	case "uint8":
+		return wireUint8, nil
+	case "int32":
+		return wireVarint32, nil
+	default:
+		return 0, fmt.Errorf("unsupported oneOf control type %q", typ)
+	}
+}
+
+func integerWire(typ string, options []string) (wireType, error) {
+	compressed := hasOption(options, "Compression")
+	bigEndian := hasOption(options, "Big Endian")
+	switch typ {
+	case "uint8":
+		return wireUint8, nil
+	case "int8":
+		return wireInt8, nil
+	case "uint16":
+		return wireUint16, nil
+	case "int16":
+		return wireInt16, nil
+	case "uint32":
+		if compressed {
+			return wireVaruint32, nil
+		}
+		return wireUint32, nil
+	case "", "int32":
+		if compressed {
+			return wireVarint32, nil
+		}
+		if bigEndian {
+			return wireBEInt32, nil
+		}
+		return wireInt32, nil
+	case "uint64":
+		if compressed {
+			return wireVaruint64, nil
+		}
+		return wireUint64, nil
+	case "int64":
+		if compressed {
+			return wireVarint64, nil
+		}
+		return wireInt64, nil
+	default:
+		return 0, fmt.Errorf("unsupported integer wire type %q", typ)
+	}
+}
+
+func hasOption(options []string, option string) bool {
+	return slices.ContainsFunc(options, func(s string) bool {
+		return strings.EqualFold(s, option)
+	})
+}
+
+func decodeScalar(io interfaceIO, wire wireType) any {
+	switch wire {
+	case wireBool:
+		var v bool
+		io.Bool(&v)
+		return v
+	case wireString:
+		var v string
+		io.String(&v)
+		return v
+	case wireUint8:
+		var v uint8
+		io.Uint8(&v)
+		return v
+	case wireInt8:
+		var v int8
+		io.Int8(&v)
+		return v
+	case wireUint16:
+		var v uint16
+		io.Uint16(&v)
+		return v
+	case wireInt16:
+		var v int16
+		io.Int16(&v)
+		return v
+	case wireUint32:
+		var v uint32
+		io.Uint32(&v)
+		return v
+	case wireInt32:
+		var v int32
+		io.Int32(&v)
+		return v
+	case wireBEInt32:
+		var v int32
+		io.BEInt32(&v)
+		return v
+	case wireVaruint32:
+		var v uint32
+		io.Varuint32(&v)
+		return v
+	case wireVarint32:
+		var v int32
+		io.Varint32(&v)
+		return v
+	case wireUint64:
+		var v uint64
+		io.Uint64(&v)
+		return v
+	case wireInt64:
+		var v int64
+		io.Int64(&v)
+		return v
+	case wireVaruint64:
+		var v uint64
+		io.Varuint64(&v)
+		return v
+	case wireVarint64:
+		var v int64
+		io.Varint64(&v)
+		return v
+	case wireFloat32:
+		var v float32
+		io.Float32(&v)
+		return v
+	case wireFloat64:
+		var v float64
+		io.Float64(&v)
+		return v
+	default:
+		io.InvalidValue(wire, "runtime schema scalar", "unknown wire type")
+		return nil
+	}
+}
+
+func encodeScalar(io interfaceIO, wire wireType, value any) {
+	switch wire {
+	case wireBool:
+		v := asBool(value)
+		io.Bool(&v)
+	case wireString:
+		v := asString(value)
+		io.String(&v)
+	case wireUint8:
+		v := uint8(asUint64(value))
+		io.Uint8(&v)
+	case wireInt8:
+		v := int8(asInt64(value))
+		io.Int8(&v)
+	case wireUint16:
+		v := uint16(asUint64(value))
+		io.Uint16(&v)
+	case wireInt16:
+		v := int16(asInt64(value))
+		io.Int16(&v)
+	case wireUint32:
+		v := uint32(asUint64(value))
+		io.Uint32(&v)
+	case wireInt32:
+		v := int32(asInt64(value))
+		io.Int32(&v)
+	case wireBEInt32:
+		v := int32(asInt64(value))
+		io.BEInt32(&v)
+	case wireVaruint32:
+		v := uint32(asUint64(value))
+		io.Varuint32(&v)
+	case wireVarint32:
+		v := int32(asInt64(value))
+		io.Varint32(&v)
+	case wireUint64:
+		v := asUint64(value)
+		io.Uint64(&v)
+	case wireInt64:
+		v := asInt64(value)
+		io.Int64(&v)
+	case wireVaruint64:
+		v := asUint64(value)
+		io.Varuint64(&v)
+	case wireVarint64:
+		v := asInt64(value)
+		io.Varint64(&v)
+	case wireFloat32:
+		v := float32(asFloat64(value))
+		io.Float32(&v)
+	case wireFloat64:
+		v := asFloat64(value)
+		io.Float64(&v)
+	default:
+		io.InvalidValue(wire, "runtime schema scalar", "unknown wire type")
+	}
+}
+
+func readControl(io interfaceIO, wire wireType) uint32 {
+	switch wire {
+	case wireUint8:
+		var v uint8
+		io.Uint8(&v)
+		return uint32(v)
+	case wireVaruint32:
+		var v uint32
+		io.Varuint32(&v)
+		return v
+	case wireVarint32:
+		var v int32
+		io.Varint32(&v)
+		return uint32(v)
+	default:
+		return uint32(asUint64(decodeScalar(io, wire)))
+	}
+}
+
+func writeControl(io interfaceIO, wire wireType, value uint32) {
+	switch wire {
+	case wireUint8:
+		v := uint8(value)
+		io.Uint8(&v)
+	case wireVaruint32:
+		io.Varuint32(&value)
+	case wireVarint32:
+		v := int32(value)
+		io.Varint32(&v)
+	default:
+		encodeScalar(io, wire, value)
+	}
+}
+
+func decodeEnum(io interfaceIO, field fieldSpec, value any) any {
+	index := asUint64(value)
+	if index >= uint64(len(field.enum)) {
+		io.InvalidValue(index, field.name, "unknown enum ordinal")
+		return value
+	}
+	return field.enum[index]
+}
+
+func encodeEnumValue(io interfaceIO, field fieldSpec, value any) any {
+	name, ok := value.(string)
+	if !ok {
+		return value
+	}
+	index := slices.Index(field.enum, name)
+	if index < 0 {
+		io.InvalidValue(name, field.name, "unknown enum value")
+		return value
+	}
+	return uint64(index)
+}
+
+func variantByIndex(variants []variantSpec, index uint32) (variantSpec, bool) {
+	for _, variant := range variants {
+		if variant.index == index {
+			return variant, true
+		}
+	}
+	return variantSpec{}, false
+}
+
+func asVariant(value any) Variant {
+	switch v := value.(type) {
+	case Variant:
+		return v
+	case *Variant:
+		if v == nil {
+			return Variant{Value: map[string]any{}}
+		}
+		return *v
+	case map[string]any:
+		return Variant{Value: v}
+	default:
+		return Variant{Value: map[string]any{}}
+	}
+}
+
+func asMap(value any) map[string]any {
+	if v, ok := value.(map[string]any); ok {
+		return v
+	}
+	return map[string]any{}
+}
+
+func asSlice(value any) []any {
+	switch v := value.(type) {
+	case []any:
+		return v
+	case []map[string]any:
+		out := make([]any, len(v))
+		for i := range v {
+			out[i] = v[i]
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func asString(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	default:
+		return ""
+	}
+}
+
+func asBool(value any) bool {
+	v, _ := value.(bool)
+	return v
+}
+
+func asFloat64(value any) float64 {
+	switch v := value.(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int32:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	case json.Number:
+		f, _ := v.Float64()
+		return f
+	default:
+		return 0
+	}
+}
+
+func asInt64(value any) int64 {
+	switch v := value.(type) {
+	case int:
+		return int64(v)
+	case int8:
+		return int64(v)
+	case int16:
+		return int64(v)
+	case int32:
+		return int64(v)
+	case int64:
+		return v
+	case uint:
+		if uint64(v) > math.MaxInt64 {
+			return 0
+		}
+		return int64(v)
+	case uint8:
+		return int64(v)
+	case uint16:
+		return int64(v)
+	case uint32:
+		return int64(v)
+	case uint64:
+		if v > math.MaxInt64 {
+			return 0
+		}
+		return int64(v)
+	case json.Number:
+		i, _ := v.Int64()
+		return i
+	default:
+		return 0
+	}
+}
+
+func asUint64(value any) uint64 {
+	switch v := value.(type) {
+	case int:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case int8:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case int16:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case int32:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case int64:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case uint:
+		return uint64(v)
+	case uint8:
+		return uint64(v)
+	case uint16:
+		return uint64(v)
+	case uint32:
+		return uint64(v)
+	case uint64:
+		return v
+	case json.Number:
+		i, err := v.Int64()
+		if err == nil && i >= 0 {
+			return uint64(i)
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+func toUint32(value any) (uint32, error) {
+	id := asUint64(value)
+	if id > math.MaxUint32 {
+		return 0, fmt.Errorf("packet ID %d overflows uint32", id)
+	}
+	return uint32(id), nil
+}


### PR DESCRIPTION
## Summary
- Add `minecraft/protocol/runtimeprotocol`, an immutable `minecraft.Protocol` implementation backed by Mojang-style JSON packet schemas.
- Overlay schema-backed packet IDs onto the fallback packet pool as `DynamicPacket` while delegating unchanged packet construction, reader/writer creation, and conversions to the fallback protocol.
- Support scalar fields, arrays, nested objects, oneOf variants, and enum-as-value encoding/decoding with focused packet round-trip tests.

## Validation
- `go test ./minecraft/protocol/runtimeprotocol ./minecraft/protocol/packet ./minecraft`
- `git diff --cached --check` before commit

## Broad-suite note
- `go test ./...` was attempted and reached the existing live-service tests. It failed after the 10-minute Go timeout in `minecraft/room.TestListen` and `minecraft/service/signaling.TestDial` while waiting for Microsoft device-code authentication prompts, not in the new runtime protocol package.

## Notes
- This is intentionally additive. It does not attempt arbitrary mid-session protocol mutation; runtime schemas are selected through the existing protocol object used by a connection.