### PR TITLE
[codex] Align packet codecs with Endstone protocol docs

### DIFF
--- a/minecraft/protocol/events.go
+++ b/minecraft/protocol/events.go
@@ -37,7 +37,7 @@ const (
 
 // lookupEvent looks up an Event matching the event type passed. False is
 // returned if no such event data exists.
-func lookupEvent(eventType int32, x *Event) bool {
+func lookupEvent(eventType uint32, x *Event) bool {
 	switch eventType {
 	case EventTypeAchievementAwarded:
 		*x = &AchievementAwardedEvent{}
@@ -110,7 +110,7 @@ func lookupEvent(eventType int32, x *Event) bool {
 }
 
 // lookupEventType looks up an event type that matches the Event passed.
-func lookupEventType(x Event, eventType *int32) bool {
+func lookupEventType(x Event, eventType *uint32) bool {
 	switch x.(type) {
 	case *AchievementAwardedEvent:
 		*eventType = EventTypeAchievementAwarded

--- a/minecraft/protocol/packet/agent_action.go
+++ b/minecraft/protocol/packet/agent_action.go
@@ -31,9 +31,9 @@ type AgentAction struct {
 	// Identifier is a JSON identifier referenced in the initial action.
 	Identifier string
 	// Action represents the action type that was requested. It is one of the constants defined above.
-	Action int32
+	Action uint32
 	// Response is a JSON string containing the response to the action.
-	Response []byte
+	Response string
 }
 
 // ID ...
@@ -43,6 +43,6 @@ func (*AgentAction) ID() uint32 {
 
 func (pk *AgentAction) Marshal(io protocol.IO) {
 	io.String(&pk.Identifier)
-	io.Int32(&pk.Action)
-	io.ByteSlice(&pk.Response)
+	io.Uint32(&pk.Action)
+	io.String(&pk.Response)
 }

--- a/minecraft/protocol/packet/boss_event.go
+++ b/minecraft/protocol/packet/boss_event.go
@@ -49,7 +49,7 @@ type BossEvent struct {
 	// unregistered from the boss fight.
 	PlayerUniqueID int64
 	// EventType is the type of the event. It is one of the BossEvent constants above.
-	EventType uint8
+	EventType uint32
 	// BossBarTitle is the title shown above the boss bar. It may be set to set
 	// a different title if the BossEntityUniqueID matches the client's entity
 	// unique ID.
@@ -64,11 +64,11 @@ type BossEvent struct {
 	HealthPercentage float32
 	// Colour is the colour of the boss bar that is shown when a player is
 	// subscribed. It is one of the BossEventColour constants listed above.
-	Colour uint8
+	Colour uint32
 	// Overlay is the overlay of the boss bar that is shown on top of the boss
 	// bar when a player is subscribed. It is one of the BossEventOverlay
 	// constants listed above.
-	Overlay uint8
+	Overlay uint32
 }
 
 // ID ...
@@ -79,10 +79,10 @@ func (*BossEvent) ID() uint32 {
 func (pk *BossEvent) Marshal(io protocol.IO) {
 	io.Varint64(&pk.BossEntityUniqueID)
 	io.Varint64(&pk.PlayerUniqueID)
-	io.Uint8(&pk.EventType)
+	io.Varuint32(&pk.EventType)
 	io.String(&pk.BossBarTitle)
 	io.String(&pk.FilteredBossBarTitle)
 	io.Float32(&pk.HealthPercentage)
-	io.Uint8(&pk.Colour)
-	io.Uint8(&pk.Overlay)
+	io.Varuint32(&pk.Colour)
+	io.Varuint32(&pk.Overlay)
 }

--- a/minecraft/protocol/packet/disconnect.go
+++ b/minecraft/protocol/packet/disconnect.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	DisconnectReasonUnknown int32 = iota
+	DisconnectReasonUnknown uint32 = iota
 	DisconnectReasonCantConnectNoInternet
 	DisconnectReasonNoPermissions
 	DisconnectReasonUnrecoverableError
@@ -152,7 +152,7 @@ const (
 type Disconnect struct {
 	// Reason is the reason for the disconnection. This affects the error code displayed on the Ore UI
 	// disconnection screen and is one of the constants above.
-	Reason int32
+	Reason uint32
 	// HideDisconnectionScreen specifies if the disconnection screen should be hidden when the client is
 	// disconnected, meaning it will be sent directly to the main menu.
 	HideDisconnectionScreen bool
@@ -170,7 +170,7 @@ func (*Disconnect) ID() uint32 {
 }
 
 func (pk *Disconnect) Marshal(io protocol.IO) {
-	io.Varint32(&pk.Reason)
+	io.Varuint32(&pk.Reason)
 	io.Bool(&pk.HideDisconnectionScreen)
 	if !pk.HideDisconnectionScreen {
 		io.String(&pk.Message)

--- a/minecraft/protocol/packet/endstone_packet_test.go
+++ b/minecraft/protocol/packet/endstone_packet_test.go
@@ -1,0 +1,160 @@
+package packet
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+func marshalPacket(pk Packet) []byte {
+	var b bytes.Buffer
+	pk.Marshal(protocol.NewWriter(&b, 0))
+	return b.Bytes()
+}
+
+func requireMarshalBytes(t *testing.T, pk Packet, want []byte) {
+	t.Helper()
+	if got := marshalPacket(pk); !bytes.Equal(got, want) {
+		t.Fatalf("%T marshal mismatch:\ngot  % x\nwant % x", pk, got, want)
+	}
+}
+
+func TestEndstoneUnsignedVaruintPacketFields(t *testing.T) {
+	tests := []struct {
+		name string
+		pk   Packet
+		want []byte
+	}{
+		{
+			name: "disconnect reason",
+			pk:   &Disconnect{Reason: 300, HideDisconnectionScreen: true},
+			want: []byte{0xac, 0x02, 0x01},
+		},
+		{
+			name: "legacy telemetry event type",
+			pk: &Event{
+				Event: &protocol.ItemUsedEvent{},
+			},
+			want: []byte{
+				0,
+				0x1f,
+				0,
+				0x14,
+				0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+				0, 0, 0, 0,
+			},
+		},
+		{
+			name: "multiplayer settings packet type",
+			pk:   &MultiPlayerSettings{ActionType: 300},
+			want: []byte{0xac, 0x02},
+		},
+		{
+			name: "npc dialogue action type",
+			pk:   &NPCDialogue{ActionType: 300},
+			want: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0xac, 0x02, 0, 0, 0, 0},
+		},
+		{
+			name: "server bound loading screen type",
+			pk:   &ServerBoundLoadingScreen{Type: 300},
+			want: []byte{0xac, 0x02, 0},
+		},
+		{
+			name: "movement effect type",
+			pk:   &MovementEffect{Type: 300, Duration: 1},
+			want: []byte{0, 0xac, 0x02, 0x02, 0},
+		},
+		{
+			name: "packet violation warning enums",
+			pk:   &PacketViolationWarning{Type: 300, Severity: 300, PacketID: 300},
+			want: []byte{0xac, 0x02, 0xac, 0x02, 0xd8, 0x04, 0},
+		},
+		{
+			name: "player action type",
+			pk:   &PlayerAction{ActionType: 300, BlockFace: 1},
+			want: []byte{0, 0xac, 0x02, 0, 0, 0, 0, 0, 0, 0x02},
+		},
+		{
+			name: "set default game type",
+			pk:   &SetDefaultGameType{GameType: 300},
+			want: []byte{0xac, 0x02},
+		},
+		{
+			name: "set last hurt by",
+			pk:   &SetLastHurtBy{EntityType: 300},
+			want: []byte{0xac, 0x02},
+		},
+		{
+			name: "set player game type",
+			pk:   &SetPlayerGameType{GameType: 300},
+			want: []byte{0xac, 0x02},
+		},
+		{
+			name: "set spawn position type",
+			pk:   &SetSpawnPosition{SpawnType: 300},
+			want: []byte{0xac, 0x02, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "set title action type",
+			pk:   &SetTitle{ActionType: 300},
+			want: []byte{0xac, 0x02, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name: "update player game type",
+			pk:   &UpdatePlayerGameType{GameType: 300},
+			want: []byte{0xac, 0x02, 0, 0},
+		},
+		{
+			name: "set hud enums",
+			pk:   &SetHud{Elements: []uint32{300}, Visibility: 300},
+			want: []byte{0x01, 0xac, 0x02, 0xac, 0x02},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireMarshalBytes(t, tt.pk, tt.want)
+		})
+	}
+}
+
+func TestEndstoneFixedWidthPacketFields(t *testing.T) {
+	requireMarshalBytes(t, &AgentAction{
+		Identifier: "request",
+		Action:     300,
+		Response:   "ok",
+	}, []byte{
+		0x07, 'r', 'e', 'q', 'u', 'e', 's', 't',
+		0x2c, 0x01, 0x00, 0x00,
+		0x02, 'o', 'k',
+	})
+
+	requireMarshalBytes(t, &BossEvent{
+		EventType: 300,
+		Colour:    300,
+		Overlay:   300,
+	}, []byte{
+		0, 0,
+		0xac, 0x02,
+		0, 0,
+		0, 0, 0, 0,
+		0xac, 0x02,
+		0xac, 0x02,
+	})
+}
+
+func TestServerPlayerPostMovePosition(t *testing.T) {
+	pk := &ServerPlayerPostMovePosition{Position: mgl32.Vec3{1, 2, 3}}
+	if pk.ID() != 16 {
+		t.Fatalf("ServerPlayerPostMovePosition ID = %d, want 16", pk.ID())
+	}
+	requireMarshalBytes(t, pk, []byte{
+		0x00, 0x00, 0x80, 0x3f,
+		0x00, 0x00, 0x00, 0x40,
+		0x00, 0x00, 0x40, 0x40,
+	})
+}

--- a/minecraft/protocol/packet/id.go
+++ b/minecraft/protocol/packet/id.go
@@ -16,7 +16,7 @@ const (
 	IDAddActor
 	IDRemoveActor
 	IDAddItemActor
-	_
+	IDServerPlayerPostMovePosition
 	IDTakeItemActor
 	IDMoveActorAbsolute
 	IDMovePlayer

--- a/minecraft/protocol/packet/mob_equipment.go
+++ b/minecraft/protocol/packet/mob_equipment.go
@@ -16,13 +16,13 @@ type MobEquipment struct {
 	NewItem protocol.ItemInstance
 	// InventorySlot is the slot in the inventory that was held. This is the same as HotBarSlot, and only
 	// remains for backwards compatibility.
-	InventorySlot byte
+	InventorySlot uint32
 	// HotBarSlot is the slot in the hot bar that was held. It is the same as InventorySlot, which is only
 	// there for backwards compatibility purposes.
-	HotBarSlot byte
+	HotBarSlot uint32
 	// WindowID is the window ID of the window that had its equipped item changed. This is usually the window
 	// ID of the normal inventory, but may also be something else, for example with the off hand.
-	WindowID byte
+	WindowID uint32
 }
 
 // ID ...
@@ -33,7 +33,7 @@ func (*MobEquipment) ID() uint32 {
 func (pk *MobEquipment) Marshal(io protocol.IO) {
 	io.Varuint64(&pk.EntityRuntimeID)
 	io.ItemInstanceNew(&pk.NewItem)
-	io.Uint8(&pk.InventorySlot)
-	io.Uint8(&pk.HotBarSlot)
-	io.Uint8(&pk.WindowID)
+	io.Varuint32(&pk.InventorySlot)
+	io.Varuint32(&pk.HotBarSlot)
+	io.Varuint32(&pk.WindowID)
 }

--- a/minecraft/protocol/packet/movement_effect.go
+++ b/minecraft/protocol/packet/movement_effect.go
@@ -18,7 +18,7 @@ type MovementEffect struct {
 	// entities are generally identified in packets using this runtime ID.
 	EntityRuntimeID uint64
 	// Type is the type of movement effect being updated. It is one of the constants found above.
-	Type int32
+	Type uint32
 	// Duration is the duration of the effect, measured in ticks.
 	Duration int32
 	// Tick is the server tick at which the packet was sent. It is used in relation to CorrectPlayerMovePrediction.
@@ -32,7 +32,7 @@ func (*MovementEffect) ID() uint32 {
 
 func (pk *MovementEffect) Marshal(io protocol.IO) {
 	io.Varuint64(&pk.EntityRuntimeID)
-	io.Varint32(&pk.Type)
+	io.Varuint32(&pk.Type)
 	io.Varint32(&pk.Duration)
 	io.Varuint64(&pk.Tick)
 }

--- a/minecraft/protocol/packet/multi_player_settings.go
+++ b/minecraft/protocol/packet/multi_player_settings.go
@@ -17,7 +17,7 @@ const (
 type MultiPlayerSettings struct {
 	// ActionType is the action that should be done when this packet is sent. It is one of the constants that
 	// may be found above.
-	ActionType int32
+	ActionType uint32
 }
 
 // ID ...
@@ -26,5 +26,5 @@ func (*MultiPlayerSettings) ID() uint32 {
 }
 
 func (pk *MultiPlayerSettings) Marshal(io protocol.IO) {
-	io.Varint32(&pk.ActionType)
+	io.Varuint32(&pk.ActionType)
 }

--- a/minecraft/protocol/packet/npc_dialogue.go
+++ b/minecraft/protocol/packet/npc_dialogue.go
@@ -3,7 +3,7 @@ package packet
 import "github.com/sandertv/gophertunnel/minecraft/protocol"
 
 const (
-	NPCDialogueActionOpen int32 = iota
+	NPCDialogueActionOpen uint32 = iota
 	NPCDialogueActionClose
 )
 
@@ -12,7 +12,7 @@ type NPCDialogue struct {
 	// EntityUniqueID is the unique ID of the NPC being requested.
 	EntityUniqueID uint64
 	// ActionType is the type of action for the packet.
-	ActionType int32
+	ActionType uint32
 	// Dialogue is the text that the client should see.
 	Dialogue string
 	// SceneName is the identifier of the scene. If this is left empty, the client will use the last scene sent to it.
@@ -31,7 +31,7 @@ func (*NPCDialogue) ID() uint32 {
 
 func (pk *NPCDialogue) Marshal(io protocol.IO) {
 	io.Uint64(&pk.EntityUniqueID)
-	io.Varint32(&pk.ActionType)
+	io.Varuint32(&pk.ActionType)
 	io.String(&pk.Dialogue)
 	io.String(&pk.SceneName)
 	io.String(&pk.NPCName)

--- a/minecraft/protocol/packet/packet_violation_warning.go
+++ b/minecraft/protocol/packet/packet_violation_warning.go
@@ -19,10 +19,10 @@ const (
 // noinspection GoNameStartsWithPackageName
 type PacketViolationWarning struct {
 	// Type is the type of violation. It is one of the constants above.
-	Type int32
+	Type uint32
 	// Severity specifies the severity of the packet violation. The action the client takes after this
 	// violation depends on the severity sent.
-	Severity int32
+	Severity uint32
 	// PacketID is the ID of the invalid packet that was received.
 	PacketID int32
 	// ViolationContext holds a description on the violation of the packet.
@@ -35,8 +35,8 @@ func (*PacketViolationWarning) ID() uint32 {
 }
 
 func (pk *PacketViolationWarning) Marshal(io protocol.IO) {
-	io.Varint32(&pk.Type)
-	io.Varint32(&pk.Severity)
+	io.Varuint32(&pk.Type)
+	io.Varuint32(&pk.Severity)
 	io.Varint32(&pk.PacketID)
 	io.String(&pk.ViolationContext)
 }

--- a/minecraft/protocol/packet/player_action.go
+++ b/minecraft/protocol/packet/player_action.go
@@ -12,7 +12,7 @@ type PlayerAction struct {
 	EntityRuntimeID uint64
 	// ActionType is the ID of the action that was executed by the player. It is one of the constants that may
 	// be found in protocol/player.go.
-	ActionType int32
+	ActionType uint32
 	// BlockPosition is the position of the target block, if the action with the ActionType set concerned a
 	// block. If that is not the case, the block position will be zero.
 	BlockPosition protocol.BlockPos
@@ -31,7 +31,7 @@ func (*PlayerAction) ID() uint32 {
 
 func (pk *PlayerAction) Marshal(io protocol.IO) {
 	io.Varuint64(&pk.EntityRuntimeID)
-	io.Varint32(&pk.ActionType)
+	io.Varuint32(&pk.ActionType)
 	io.BlockPos(&pk.BlockPosition)
 	io.BlockPos(&pk.ResultPosition)
 	io.Varint32(&pk.BlockFace)

--- a/minecraft/protocol/packet/pool.go
+++ b/minecraft/protocol/packet/pool.go
@@ -61,7 +61,9 @@ func init() {
 		IDAddActor:                   func() Packet { return &AddActor{} },
 		IDRemoveActor:                func() Packet { return &RemoveActor{} },
 		IDAddItemActor:               func() Packet { return &AddItemActor{} },
-		// ---
+		IDServerPlayerPostMovePosition: func() Packet {
+			return &ServerPlayerPostMovePosition{}
+		},
 		IDTakeItemActor:     func() Packet { return &TakeItemActor{} },
 		IDMoveActorAbsolute: func() Packet { return &MoveActorAbsolute{} },
 		IDMovePlayer:        func() Packet { return &MovePlayer{} },

--- a/minecraft/protocol/packet/server_bound_loading_screen.go
+++ b/minecraft/protocol/packet/server_bound_loading_screen.go
@@ -14,7 +14,7 @@ const (
 // screen that the client is currently displaying.
 type ServerBoundLoadingScreen struct {
 	// Type is the type of the loading screen event. It is one of the constants that may be found above.
-	Type int32
+	Type uint32
 	// LoadingScreenID is the ID of the screen that was previously sent by the server in the ChangeDimension
 	// packet. The server should validate that the ID matches the last one it sent.
 	LoadingScreenID protocol.Optional[uint32]
@@ -26,6 +26,6 @@ func (*ServerBoundLoadingScreen) ID() uint32 {
 }
 
 func (pk *ServerBoundLoadingScreen) Marshal(io protocol.IO) {
-	io.Varint32(&pk.Type)
+	io.Varuint32(&pk.Type)
 	protocol.OptionalFunc(io, &pk.LoadingScreenID, io.Uint32)
 }

--- a/minecraft/protocol/packet/server_player_post_move_position.go
+++ b/minecraft/protocol/packet/server_player_post_move_position.go
@@ -1,0 +1,21 @@
+package packet
+
+import (
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+)
+
+// ServerPlayerPostMovePosition is sent by the server with a debug-draw position after player movement.
+type ServerPlayerPostMovePosition struct {
+	// Position is the debug-draw position sent by the server.
+	Position mgl32.Vec3
+}
+
+// ID ...
+func (*ServerPlayerPostMovePosition) ID() uint32 {
+	return IDServerPlayerPostMovePosition
+}
+
+func (pk *ServerPlayerPostMovePosition) Marshal(io protocol.IO) {
+	io.Vec3(&pk.Position)
+}

--- a/minecraft/protocol/packet/set_default_game_type.go
+++ b/minecraft/protocol/packet/set_default_game_type.go
@@ -10,7 +10,7 @@ import (
 type SetDefaultGameType struct {
 	// GameType is the new game type that is set. When sent by the client, this is the requested new default
 	// game type.
-	GameType int32
+	GameType uint32
 }
 
 // ID ...
@@ -19,5 +19,5 @@ func (*SetDefaultGameType) ID() uint32 {
 }
 
 func (pk *SetDefaultGameType) Marshal(io protocol.IO) {
-	io.Varint32(&pk.GameType)
+	io.Varuint32(&pk.GameType)
 }

--- a/minecraft/protocol/packet/set_hud.go
+++ b/minecraft/protocol/packet/set_hud.go
@@ -29,10 +29,10 @@ const (
 type SetHud struct {
 	// Elements is a list of HUD elements that are being modified. The values can be any of the HudElement
 	// constants above.
-	Elements []int32
+	Elements []uint32
 	// Visibility represents the new visibility of the specified Elements. It can be any of the HudVisibility
 	// constants above.
-	Visibility int32
+	Visibility uint32
 }
 
 // ID ...
@@ -41,6 +41,6 @@ func (*SetHud) ID() uint32 {
 }
 
 func (pk *SetHud) Marshal(io protocol.IO) {
-	protocol.FuncSlice(io, &pk.Elements, io.Varint32)
-	io.Varint32(&pk.Visibility)
+	protocol.FuncSlice(io, &pk.Elements, io.Varuint32)
+	io.Varuint32(&pk.Visibility)
 }

--- a/minecraft/protocol/packet/set_last_hurt_by.go
+++ b/minecraft/protocol/packet/set_last_hurt_by.go
@@ -9,7 +9,7 @@ import (
 // packet is sent or not.
 type SetLastHurtBy struct {
 	// EntityType is the numerical type of the entity that the player was last hurt by.
-	EntityType int32
+	EntityType uint32
 }
 
 // ID ...
@@ -18,5 +18,5 @@ func (*SetLastHurtBy) ID() uint32 {
 }
 
 func (pk *SetLastHurtBy) Marshal(io protocol.IO) {
-	io.Varint32(&pk.EntityType)
+	io.Varuint32(&pk.EntityType)
 }

--- a/minecraft/protocol/packet/set_player_game_type.go
+++ b/minecraft/protocol/packet/set_player_game_type.go
@@ -20,7 +20,7 @@ type SetPlayerGameType struct {
 	// GameType is the new game type of the player. It is one of the constants that can be found above. Some
 	// of these game types require additional flags to be set in an AdventureSettings packet for the game mode
 	// to obtain its full functionality.
-	GameType int32
+	GameType uint32
 }
 
 // ID ...
@@ -29,5 +29,5 @@ func (*SetPlayerGameType) ID() uint32 {
 }
 
 func (pk *SetPlayerGameType) Marshal(io protocol.IO) {
-	io.Varint32(&pk.GameType)
+	io.Varuint32(&pk.GameType)
 }

--- a/minecraft/protocol/packet/set_spawn_position.go
+++ b/minecraft/protocol/packet/set_spawn_position.go
@@ -15,7 +15,7 @@ type SetSpawnPosition struct {
 	// SpawnType is the type of spawn to set. It is either SpawnTypePlayer or SpawnTypeWorld, and specifies
 	// the behaviour of the spawn set. If SpawnTypeWorld is set, the position to which compasses will point is
 	// also changed.
-	SpawnType int32
+	SpawnType uint32
 	// Position is the new position of the spawn that was set. If SpawnType is SpawnTypeWorld, compasses will
 	// point to this position. As of 1.16, Position is always the position of the player.
 	Position protocol.BlockPos
@@ -34,7 +34,7 @@ func (*SetSpawnPosition) ID() uint32 {
 }
 
 func (pk *SetSpawnPosition) Marshal(io protocol.IO) {
-	io.Varint32(&pk.SpawnType)
+	io.Varuint32(&pk.SpawnType)
 	io.BlockPos(&pk.Position)
 	io.Varint32(&pk.Dimension)
 	io.BlockPos(&pk.SpawnPosition)

--- a/minecraft/protocol/packet/set_title.go
+++ b/minecraft/protocol/packet/set_title.go
@@ -21,7 +21,7 @@ const (
 type SetTitle struct {
 	// ActionType is the type of the action that should be executed upon the title of a player. It is one of
 	// the constants above and specifies the response of the client to the packet.
-	ActionType int32
+	ActionType uint32
 	// Text is the text of the title, which has a different meaning depending on the ActionType that the
 	// packet has. The text is the text of a title, subtitle or action bar, depending on the type set.
 	Text string
@@ -50,7 +50,7 @@ func (*SetTitle) ID() uint32 {
 }
 
 func (pk *SetTitle) Marshal(io protocol.IO) {
-	io.Varint32(&pk.ActionType)
+	io.Varuint32(&pk.ActionType)
 	io.String(&pk.Text)
 	io.Varint32(&pk.FadeInDuration)
 	io.Varint32(&pk.RemainDuration)

--- a/minecraft/protocol/packet/update_player_game_type.go
+++ b/minecraft/protocol/packet/update_player_game_type.go
@@ -10,7 +10,7 @@ type UpdatePlayerGameType struct {
 	// GameType is the new game type of the player. It is one of the constants that can be found in
 	// set_player_game_type.go. Some of these game types require additional flags to be set in an
 	// UpdateAbilities packet for the game mode to obtain its full functionality.
-	GameType int32
+	GameType uint32
 	// PlayerUniqueID is the entity unique ID of the player that should have its game mode updated. If this
 	// packet is sent to other clients with the player unique ID of another player, nothing happens.
 	PlayerUniqueID int64
@@ -24,7 +24,7 @@ func (*UpdatePlayerGameType) ID() uint32 {
 }
 
 func (pk *UpdatePlayerGameType) Marshal(io protocol.IO) {
-	io.Varint32(&pk.GameType)
+	io.Varuint32(&pk.GameType)
 	io.Varint64(&pk.PlayerUniqueID)
 	io.Varuint64(&pk.Tick)
 }

--- a/minecraft/protocol/reader.go
+++ b/minecraft/protocol/reader.go
@@ -621,8 +621,8 @@ func (r *Reader) Recipe(x *Recipe) {
 
 // EventType reads an Event's type from the reader.
 func (r *Reader) EventType(x *Event) {
-	var t int32
-	r.Varint32(&t)
+	var t uint32
+	r.Varuint32(&t)
 	if !lookupEvent(t, x) {
 		r.UnknownEnumOption(t, "event packet event type")
 	}

--- a/minecraft/protocol/writer.go
+++ b/minecraft/protocol/writer.go
@@ -527,11 +527,11 @@ func (w *Writer) Recipe(x *Recipe) {
 
 // EventType writes an Event to the writer.
 func (w *Writer) EventType(x *Event) {
-	var t int32
+	var t uint32
 	if !lookupEventType(*x, &t) {
 		w.UnknownEnumOption(*x, "event packet event type")
 	}
-	w.Varint32(&t)
+	w.Varuint32(&t)
 }
 
 // EventOrdinal writes an Event ordinal to the writer.


### PR DESCRIPTION
## Summary

Align packet definitions with EndstoneMC/protocol-docs r26_u3 (commit `f00805e98363c6c3024ffd73a56caa5a723cca3a`).

## Endstone-backed changes

- Added `ServerPlayerPostMovePosition` at packet ID 16 and registered it in the packet pool, matching [`ServerPlayerPostMovePositionPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/ServerPlayerPostMovePositionPacket.json).
- Updated `AgentAction` to encode `Action` as `uint32` and `Response` as a protocol string, matching [`AgentActionEventPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/AgentActionEventPacket.json).
- Updated `BossEvent` to encode `EventType`, `Colour`, and `Overlay` as `uvarint32`, matching [`BossEventPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/BossEventPacket.json).
- Updated `Disconnect.Reason` to encode as `uvarint32`, matching [`DisconnectPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/DisconnectPacket.json).
- Updated legacy telemetry event type read/write helpers to use `uvarint32`, matching [`LegacyTelemetryEventPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/LegacyTelemetryEventPacket.json).
- Updated `MobEquipment` slot and container fields to encode as `uvarint32`, matching [`MobEquipmentPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/MobEquipmentPacket.json).
- Updated `MovementEffect.Type` to encode as `uvarint32`, matching [`MovementEffectPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/MovementEffectPacket.json).
- Updated `MultiPlayerSettings.ActionType` to encode as `uvarint32`, matching [`MultiplayerSettingsPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/MultiplayerSettingsPacket.json).
- Updated `NPCDialogue.ActionType` to encode as `uvarint32`, matching [`NpcDialoguePacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/NpcDialoguePacket.json).
- Updated `PacketViolationWarning.Type` and `Severity` to encode as `uvarint32`, matching [`PacketViolationWarningPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/PacketViolationWarningPacket.json).
- Updated `PlayerAction.ActionType` to encode as `uvarint32`, matching [`PlayerActionPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/PlayerActionPacket.json).
- Updated `ServerBoundLoadingScreen.Type` to encode as `uvarint32`, matching [`ServerboundLoadingScreenPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/ServerboundLoadingScreenPacket.json).
- Updated `SetDefaultGameType.GameType` to encode as `uvarint32`, matching [`SetDefaultGameTypePacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetDefaultGameTypePacket.json).
- Updated `SetHud.Elements` and `Visibility` to encode as `uvarint32`, matching [`SetHudPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetHudPacket.json).
- Updated `SetLastHurtBy.EntityType` to encode as `uvarint32`, matching [`SetLastHurtByPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetLastHurtByPacket.json).
- Updated `SetPlayerGameType.GameType` to encode as `uvarint32`, matching [`SetPlayerGameTypePacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetPlayerGameTypePacket.json).
- Updated `SetSpawnPosition.SpawnType` to encode as `uvarint32`, matching [`SetSpawnPositionPacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetSpawnPositionPacket.json).
- Updated `SetTitle.ActionType` to encode as `uvarint32`, matching [`SetTitlePacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/SetTitlePacket.json).
- Updated `UpdatePlayerGameType.GameType` to encode as `uvarint32`, matching [`UpdatePlayerGameTypePacket.json`](https://github.com/EndstoneMC/protocol-docs/blob/f00805e98363c6c3024ffd73a56caa5a723cca3a/packets/UpdatePlayerGameTypePacket.json).
- Added packet marshal tests that lock the Endstone-backed scalar encodings and the new ID-16 packet definition.

## Validation

- `go test ./...`
- `git diff --check`
- Cross-checked packet IDs against Endstone packet JSON: 0 ID mismatches.
- Cross-checked explicit Endstone `uvarint32` packet fields against gophertunnel writers: 0 remaining missing unsigned-writer evidence.
