### PR TITLE
Fixed unauthenticated players being unable to connect

### DIFF
--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -72,7 +72,7 @@ func (data IdentityData) Validate() error {
 	if id, err := uuid.Parse(data.Identity); err != nil || id == uuid.Nil {
 		return fmt.Errorf("UUID must be parseable as a valid UUID, but got %v", data.Identity)
 	}
-	nameLimit := 15
+	nameLimit := 16
 	if len(data.DisplayName) == 0 || len(data.DisplayName) > nameLimit {
 		return fmt.Errorf("DisplayName must not be empty or longer than %d characters, but got %v characters", nameLimit, len(data.DisplayName))
 	}
@@ -82,14 +82,8 @@ func (data IdentityData) Validate() error {
 	if data.DisplayName[0] >= '0' && data.DisplayName[0] <= '9' {
 		return fmt.Errorf("DisplayName may not have a number as first character, but got %v", data.DisplayName)
 	}
-	if data.XUID != "" {
-		if !checkOnlineUsername(data.DisplayName) {
-			return fmt.Errorf("DisplayName for authorized client must only contain numbers, Latin letters and spaces, but got %v", data.DisplayName)
-		}
-	} else {
-		if !checkOfflineUsername(data.DisplayName) {
-			return fmt.Errorf("DisplayName for unauthorized client must only contain numbers, letters and spaces, but got %v", data.DisplayName)
-		}
+	if !checkOnlineUsername(data.DisplayName) {
+		return fmt.Errorf("DisplayName for authorized client must only contain numbers, Latin letters and spaces, but got %v", data.DisplayName)
 	}
 	// We check here if the name contains at least 2 spaces after each other, which is not allowed. The name
 	// is only allowed to have single spaces.
@@ -388,6 +382,13 @@ func (data ClientData) Validate() error {
 	}
 	if data.UIProfile < 0 || data.UIProfile > 2 {
 		return fmt.Errorf("UIProfile must be between 0-2, but got %v", data.UIProfile)
+	}
+	nameLimit := 16
+	if len(data.ThirdPartyName) == 0 || len(data.ThirdPartyName) > nameLimit {
+		return fmt.Errorf("ThirdPartyName must not be empty or longer than %d characters, but got %v characters", nameLimit, len(data.ThirdPartyName))
+	}
+	if !checkOfflineUsername(data.ThirdPartyName) {
+		return fmt.Errorf("ThirdPartyName for client must only contain numbers, Latin letters and spaces, but got %v", data.ThirdPartyName)
 	}
 	return nil
 }

--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -65,14 +65,14 @@ func (data IdentityData) Validate() error {
 	if _, err := strconv.ParseInt(data.XUID, 10, 64); err != nil && len(data.XUID) != 0 {
 		return fmt.Errorf("XUID must be parseable as an int64, but got %v", data.XUID)
 	}
+	if data.XUID == "" {
+		// Non-authenticated clients don't have DisplayName nor Identity. This will be filled with their ClientData when parsing their request.
+		return nil
+	}
 	if id, err := uuid.Parse(data.Identity); err != nil || id == uuid.Nil {
 		return fmt.Errorf("UUID must be parseable as a valid UUID, but got %v", data.Identity)
 	}
 	nameLimit := 15
-	if data.XUID == "" {
-		// Non-authenticated clients can have up to 16 characters in their name.
-		nameLimit = 16
-	}
 	if len(data.DisplayName) == 0 || len(data.DisplayName) > nameLimit {
 		return fmt.Errorf("DisplayName must not be empty or longer than %d characters, but got %v characters", nameLimit, len(data.DisplayName))
 	}

--- a/minecraft/protocol/login/data.go
+++ b/minecraft/protocol/login/data.go
@@ -72,7 +72,7 @@ func (data IdentityData) Validate() error {
 	if id, err := uuid.Parse(data.Identity); err != nil || id == uuid.Nil {
 		return fmt.Errorf("UUID must be parseable as a valid UUID, but got %v", data.Identity)
 	}
-	nameLimit := 16
+	nameLimit := 15
 	if len(data.DisplayName) == 0 || len(data.DisplayName) > nameLimit {
 		return fmt.Errorf("DisplayName must not be empty or longer than %d characters, but got %v characters", nameLimit, len(data.DisplayName))
 	}

--- a/minecraft/protocol/login/request.go
+++ b/minecraft/protocol/login/request.go
@@ -175,7 +175,6 @@ func Parse(request []byte, verifier *oidc.IDTokenVerifier) (IdentityData, Client
 		return iData, cData, res, fmt.Errorf("validate client data: %w", err)
 	}
 	if !authenticated {
-		iData.Identity = cData.SelfSignedID
 		iData.DisplayName = cData.ThirdPartyName
 	}
 	return iData, cData, AuthResult{PublicKey: key, XBOXLiveAuthenticated: authenticated}, nil
@@ -451,7 +450,7 @@ type tokenClaims struct {
 	DisplayName string `json:"xname"`
 	// Identity is the UUID of the player. It is only set for offline logins where
 	// the UUID cannot be derived from the XUID.
-	Identity string `json:"identity,omitempty"`
+	Identity string `json:"leguuid,omitempty"`
 }
 
 // identityData converts the OIDC tokenClaims into IdentityData.

--- a/minecraft/protocol/login/request.go
+++ b/minecraft/protocol/login/request.go
@@ -174,6 +174,10 @@ func Parse(request []byte, verifier *oidc.IDTokenVerifier) (IdentityData, Client
 	if err := cData.Validate(); err != nil {
 		return iData, cData, res, fmt.Errorf("validate client data: %w", err)
 	}
+	if !authenticated {
+		iData.Identity = cData.SelfSignedID
+		iData.DisplayName = cData.ThirdPartyName
+	}
 	return iData, cData, AuthResult{PublicKey: key, XBOXLiveAuthenticated: authenticated}, nil
 }
 
@@ -457,8 +461,6 @@ func (tc tokenClaims) identityData() IdentityData {
 	if identity == "" {
 		if tc.XUID != "" {
 			identity = identityFromXUID(tc.XUID).String()
-		} else {
-			identity = uuid.New().String()
 		}
 	}
 	return IdentityData{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication and identity derivation for all login paths; behavior change for OIDC tokens without XUID/identity could affect edge cases beyond offline play.
> 
> **Overview**
> Fixes login parsing so **offline / non–Xbox Live** clients no longer fail validation before their identity is known.
> 
> **`IdentityData.Validate`** now returns early when `XUID` is empty, skipping `DisplayName` and `Identity` checks that used to run on empty token/chain fields. Authenticated players still get the 15-character online name rules on `DisplayName`; the old offline branch on `DisplayName` (16 chars + `checkOfflineUsername`) is removed.
> 
> **`ClientData.Validate`** now enforces **`ThirdPartyName`** (non-empty, max 16 characters, `checkOfflineUsername`), where offline display names actually live.
> 
> In **`Parse`**, after client data is validated, unauthenticated sessions set **`Identity`** from `SelfSignedID` and **`DisplayName`** from `ThirdPartyName`. **`tokenClaims.identityData`** no longer assigns a random UUID when there is no XUID and no `identity` claim—identity for offline flows comes from that post-parse step instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22384d6b93a710e7c48d3514afccfe9626b10116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login identity validation by handling authenticated and non-authenticated clients differently.
  * Added stricter validation for third-party usernames (must be non-empty, up to 16 characters, and follow offline naming rules).
  * Updated authenticated display name handling to align with online naming rules and enforce a 15-character limit.
  * Refined identity derivation during parsing so display name is populated appropriately based on authentication status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->